### PR TITLE
Fixes to atcmd-board and gpio-board.

### DIFF
--- a/board/RHF76_STM32L072CBxx_Lora/Src/atcmd-board.c
+++ b/board/RHF76_STM32L072CBxx_Lora/Src/atcmd-board.c
@@ -31,7 +31,7 @@ uint8_t isspace(char x)
 /*ASCÂë×ªÕûĞÎ*/
 int asc2int(const uint8_t * asc, uint8_t len)
 {
-    uint8_t i;
+    uint8_t i = 0;
     char c;
     char sign;
     int total = 0;
@@ -234,7 +234,7 @@ uint8_t at_key_handle(uint8_t *param, uint16_t size)
      * AT+KEY=APPKEY, "2B7E151628AED2A6ABF7158809CF4F3C"
      */
     uint8_t key[16];
-    uint8_t i;
+    uint8_t i = 0;
     MibRequestConfirm_t mibReq;
     
     while(param[i++] != '\"');

--- a/board/RHF76_STM32L072CBxx_Lora/Src/gpio-board.c
+++ b/board/RHF76_STM32L072CBxx_Lora/Src/gpio-board.c
@@ -249,12 +249,13 @@ void GpioMcuRemoveInterrupt( Gpio_t *obj )
 
 void GpioMcuWrite( Gpio_t *obj, uint32_t value )
 {
+    if( obj == NULL )
+    {
+        assert_param( LORA_FAIL );
+    }
+
     if( obj->pin < IOE_0 )
     {
-        if( obj == NULL )
-        {
-            assert_param( LORA_FAIL );
-        }
         // Check if pin is not connected
         if( obj->pin == NC )
         {
@@ -273,13 +274,13 @@ void GpioMcuWrite( Gpio_t *obj, uint32_t value )
 
 void GpioMcuToggle( Gpio_t *obj )
 {
+    if( obj == NULL )
+    {
+        assert_param( LORA_FAIL );
+    }
+
     if( obj->pin < IOE_0 )
     {
-        if( obj == NULL )
-        {
-            assert_param( LORA_FAIL );
-        }
-
         // Check if pin is not connected
         if( obj->pin == NC )
         {
@@ -298,12 +299,13 @@ void GpioMcuToggle( Gpio_t *obj )
 
 uint32_t GpioMcuRead( Gpio_t *obj )
 {
+    if( obj == NULL )
+    {
+        assert_param( LORA_FAIL );
+    }
+
     if( obj->pin < IOE_0 )
     {
-        if( obj == NULL )
-        {
-            assert_param( LORA_FAIL );
-        }
         // Check if pin is not connected
         if( obj->pin == NC )
         {


### PR DESCRIPTION
atcmd-board had two uninitialised loop variables
gpio-board had three instances where the assert happened too late, so you'd get a crash without information.
