### PR TITLE
mbedtls: fix memory leak due to OR condition check

### DIFF
--- a/platform/vendor_bsp/nordic/nRF5_SDK_15.3.0_59ac345/external/mbedtls/library/dhm.c
+++ b/platform/vendor_bsp/nordic/nRF5_SDK_15.3.0_59ac345/external/mbedtls/library/dhm.c
@@ -536,6 +536,7 @@ static int load_file( const char *path, unsigned char **buf, size_t *n )
         ( *buf = mbedtls_calloc( 1, *n + 1 ) ) == NULL )
     {
         fclose( f );
+        mbedtls_free( *buf );
         return( MBEDTLS_ERR_DHM_ALLOC_FAILED );
     }
 

--- a/platform/vendor_bsp/nordic/nRF5_SDK_15.3.0_59ac345/external/mbedtls/library/pkparse.c
+++ b/platform/vendor_bsp/nordic/nRF5_SDK_15.3.0_59ac345/external/mbedtls/library/pkparse.c
@@ -95,6 +95,7 @@ int mbedtls_pk_load_file( const char *path, unsigned char **buf, size_t *n )
         ( *buf = mbedtls_calloc( 1, *n + 1 ) ) == NULL )
     {
         fclose( f );
+        mbedtls_free( *buf );
         return( MBEDTLS_ERR_PK_ALLOC_FAILED );
     }
 


### PR DESCRIPTION
calloc is called within an IF with 2 conditions.
If the other condition fails, but calloc succeeds, the memory will be leaked.
So call free on that memory regardless, as freeing NULL has no ill effect.