### PR TITLE
risc-v add irq stack

### DIFF
--- a/arch/risc-v/bumblebee/gcc/riscv_port.h
+++ b/arch/risc-v/bumblebee/gcc/riscv_port.h
@@ -25,16 +25,16 @@
 #define CLINT_MTIME     0x0000
 
 // the bumblebee mstatus register is different
-// name         bit         detail
-// INTERRUPT    31          0: exception or nmi, 1 irq
-// MINHV        30          reading irq vector table
-// MPP          29:28       == mstatus.MPP
-// MPIE         27          == mstatus.MPIE
-// Reserved     26:24       0
-// MPIL         23:16       previous interrupt level
-// Reserved     15:12       0
-// EXCCODE      11:0        exception code
-#define SOC_MCAUSE_EXP_MASK 0x00000FFF
+// name             bit         detail
+// INTERRUPT        31          0: exception or nmi, 1 irq
+// MINHV            30          reading irq vector table
+// MPP              29:28       == mstatus.MPP
+// MPIE             27          == mstatus.MPIE
+// Reserved         26:24       0
+// MPIL             23:16       previous interrupt level
+// Reserved         15:12       0
+// EXCCODE          11:0        exception code
+#define MCAUSE_EXP_CODE_MASK    0x00000FFF
 
 #ifndef __ASSEMBLER__
 void port_cpu_init();

--- a/arch/risc-v/bumblebee/gcc/riscv_port_s.S
+++ b/arch/risc-v/bumblebee/gcc/riscv_port_s.S
@@ -7,6 +7,6 @@
 irq_entry:
     j rv32_exception_entry
 
-.align 6
+.align 2
 trap_entry:
     j rv32_exception_entry

--- a/arch/risc-v/common/tos_cpu.c
+++ b/arch/risc-v/common/tos_cpu.c
@@ -1,6 +1,14 @@
 #include <tos.h>
 #include <riscv_port.h>
 
+#ifndef TOS_CFG_IRQ_STK_SIZE
+#warning "did not specify the irq stack size, use default value"
+#define TOS_CFG_IRQ_STK_SIZE 128
+#endif
+
+k_stack_t k_irq_stk[TOS_CFG_IRQ_STK_SIZE];
+const k_stack_t *k_irq_stk_top = (k_stack_t *) ((char *)(k_irq_stk + TOS_CFG_IRQ_STK_SIZE) - sizeof(cpu_data_t));
+
 __KERNEL__ void cpu_systick_init(k_cycle_t cycle_per_tick)
 {
     port_systick_priority_set(TOS_CFG_CPU_SYSTICK_PRIO);
@@ -9,6 +17,7 @@ __KERNEL__ void cpu_systick_init(k_cycle_t cycle_per_tick)
 
 __KERNEL__ void cpu_init(void) {
     k_cpu_cycle_per_tick = TOS_CFG_CPU_CLOCK / k_cpu_tick_per_second;
+
     cpu_systick_init(k_cpu_cycle_per_tick);
 
     port_cpu_init();
@@ -172,5 +181,4 @@ __API__ uint32_t tos_cpu_clz(uint32_t val)
 
     return (nbr_lead_zeros);
 }
-
 

--- a/arch/risc-v/common/tos_cpu.c
+++ b/arch/risc-v/common/tos_cpu.c
@@ -122,7 +122,7 @@ __KERNEL__ k_stack_t *cpu_task_stk_init(void *entry,
     regs->a0        = (cpu_data_t)arg;          // argument
     regs->ra        = (cpu_data_t)0xACE00ACE;   // return address
     regs->mstatus   = (cpu_data_t)0x00001880;   // return to machine mode and enable interrupt
-    regs->epc       = (cpu_data_t)entry;        // task entry
+    regs->mepc      = (cpu_data_t)entry;        // task entry
 
     return (k_stack_t*)sp;
 }

--- a/arch/risc-v/rv32i/gcc/port_s.S
+++ b/arch/risc-v/rv32i/gcc/port_s.S
@@ -226,7 +226,6 @@ port_context_switch:
     sw x30, __reg_x30_OFFSET(sp)
     sw x31, __reg_x31_OFFSET(sp)
 
-
     sw     ra,  __reg_mepc_OFFSET(sp)
 
     csrr   t0,  mstatus
@@ -324,12 +323,10 @@ rv32_exception_entry:
     mv      t0, sp
     la      t1, k_irq_stk_top
     lw      sp, (t1)
-    andi    sp, sp, 0xFFFFFFF0
     sw      t0, (sp)
 
-
     // get irq num and call irq handler
-    li      t0,  SOC_MCAUSE_EXP_MASK
+    li      t0,  MCAUSE_EXP_CODE_MASK
     csrr    a0,  mcause
     and     a0,  a0, t0
     call    cpu_irq_entry

--- a/arch/risc-v/rv32i/gcc/port_s.S
+++ b/arch/risc-v/rv32i/gcc/port_s.S
@@ -320,11 +320,23 @@ rv32_exception_entry:
     csrr    t0,  mstatus
     sw      t0,  __reg_mstatus__OFFSET(sp)
 
+    // switch to irq stack
+    mv      t0, sp
+    la      t1, k_irq_stk_top
+    lw      sp, (t1)
+    andi    sp, sp, 0xFFFFFFF0
+    sw      t0, (sp)
+
+
     // get irq num and call irq handler
     li      t0,  SOC_MCAUSE_EXP_MASK
     csrr    a0,  mcause
     and     a0,  a0, t0
     call    cpu_irq_entry
+
+    // switch back to task stack
+    lw      t0, (sp)
+    mv      sp, t0
 
     la      t0,  k_curr_task
     la      t1,  k_next_task

--- a/arch/risc-v/rv32i/gcc/port_s.S
+++ b/arch/risc-v/rv32i/gcc/port_s.S
@@ -150,52 +150,14 @@ port_sched_start:
     addi    t1, sp, 128
     sw      t1, (t0)
 
-    // restore context
-    lw      t0, __reg_mepc__OFFSET(sp)
-    csrw    mepc, t0
-
-    lw      t0, __reg_mstatus__OFFSET(sp)
-    csrw    mstatus, t0
-
-    lw x3, __reg_x3_OFFSET(sp)
-    lw x4, __reg_x4_OFFSET(sp)
-    lw x5, __reg_x5_OFFSET(sp)
-    lw x6, __reg_x6_OFFSET(sp)
-    lw x7, __reg_x7_OFFSET(sp)
-    lw x8, __reg_x8_OFFSET(sp)
-    lw x9, __reg_x9_OFFSET(sp)
-    lw x10, __reg_x10_OFFSET(sp)
-    lw x11, __reg_x11_OFFSET(sp)
-    lw x12, __reg_x12_OFFSET(sp)
-    lw x13, __reg_x13_OFFSET(sp)
-    lw x14, __reg_x14_OFFSET(sp)
-    lw x15, __reg_x15_OFFSET(sp)
-    lw x16, __reg_x16_OFFSET(sp)
-    lw x17, __reg_x17_OFFSET(sp)
-    lw x18, __reg_x18_OFFSET(sp)
-    lw x19, __reg_x19_OFFSET(sp)
-    lw x20, __reg_x20_OFFSET(sp)
-    lw x21, __reg_x21_OFFSET(sp)
-    lw x22, __reg_x22_OFFSET(sp)
-    lw x23, __reg_x23_OFFSET(sp)
-    lw x24, __reg_x24_OFFSET(sp)
-    lw x25, __reg_x25_OFFSET(sp)
-    lw x26, __reg_x26_OFFSET(sp)
-    lw x27, __reg_x27_OFFSET(sp)
-    lw x28, __reg_x28_OFFSET(sp)
-    lw x29, __reg_x29_OFFSET(sp)
-    lw x30, __reg_x30_OFFSET(sp)
-    lw x31, __reg_x31_OFFSET(sp)
-
-    addi    sp, sp, 128
-
-    mret
+    j       restore_context
 
 
 .align 2
 .type port_context_switch, %function
 port_context_switch:
     addi   sp, sp, -128
+    sw x1, __reg_x1_OFFSET(sp)
     sw x3, __reg_x3_OFFSET(sp)
     sw x4, __reg_x4_OFFSET(sp)
     sw x5, __reg_x5_OFFSET(sp)
@@ -233,20 +195,24 @@ port_context_switch:
     or     t0,  t0, t1
     sw     t0,  __reg_mstatus_OFFSET(sp)
 
-    // save sp to k_curr_task.sp
+
     la      t0, k_curr_task         // t0 = &k_curr_task
-    lw      t1, (t0)
-    sw      sp, (t1)
+    la      t1, k_next_task         // t1 = &k_next_task
+
+switch_task:
+    // save sp to k_curr_task.sp
+    lw      t2, (t0)
+    sw      sp, (t2)
 
     // switch task
     // k_curr_task = k_next_task
-    la      t1, k_next_task         // t1 = &k_next_task
     lw      t1, (t1)                // t1 = k_next_task
     sw      t1, (t0)
 
     // load new task sp
     lw      sp, (t1)
 
+restore_context:
     // restore context
     lw      t0,   __reg_mepc_OFFSET(sp)
     csrw    mepc, t0
@@ -254,6 +220,7 @@ port_context_switch:
     lw      t0,   __reg_mstatus_OFFSET(sp)
     csrw    mstatus, t0
 
+    lw x1, __reg_x1_OFFSET(sp)
     lw x3, __reg_x3_OFFSET(sp)
     lw x4, __reg_x4_OFFSET(sp)
     lw x5, __reg_x5_OFFSET(sp)
@@ -353,30 +320,7 @@ rv32_exception_entry:
     sw s10, __reg_s10__OFFSET(sp)
     sw s11, __reg_s11__OFFSET(sp)
 
-    // save sp to k_curr_task.sp
-    la      t0, k_curr_task         // t0 = &k_curr_task
-    lw      t2, (t0)                // t2 =  k_curr_task->sp
-    sw      sp, (t2)                // k_curr_task->sp = sp
-
-    // switch task
-    lw      t1, (t1)                // t1 =  k_next_task
-    sw      t1, (t0)                // k_curr_task = k_next_task
-
-    // load new task sp
-    lw      sp, (t1)
-
-    lw s0, __reg_s0__OFFSET(sp)
-    lw s1, __reg_s1__OFFSET(sp)
-    lw s2, __reg_s2__OFFSET(sp)
-    lw s3, __reg_s3__OFFSET(sp)
-    lw s4, __reg_s4__OFFSET(sp)
-    lw s5, __reg_s5__OFFSET(sp)
-    lw s6, __reg_s6__OFFSET(sp)
-    lw s7, __reg_s7__OFFSET(sp)
-    lw s8, __reg_s8__OFFSET(sp)
-    lw s9, __reg_s9__OFFSET(sp)
-    lw s10, __reg_s10__OFFSET(sp)
-    lw s11, __reg_s11__OFFSET(sp)
+    j switch_task
 
 irq_restore:
     lw      t0,   __reg_mepc_OFFSET(sp)
@@ -406,5 +350,3 @@ irq_restore:
     addi    sp, sp, 128
 
     mret
-
-

--- a/arch/risc-v/rv32i/gcc/port_s.S
+++ b/arch/risc-v/rv32i/gcc/port_s.S
@@ -250,7 +250,6 @@ restore_context:
     lw x29, __reg_x29_OFFSET(sp)
     lw x30, __reg_x30_OFFSET(sp)
     lw x31, __reg_x31_OFFSET(sp)
-
     addi    sp, sp, 128
 
     mret
@@ -260,7 +259,6 @@ restore_context:
 .global rv32_exception_entry
 rv32_exception_entry:
     addi   sp,  sp, -128
-
     sw ra, __reg_ra__OFFSET(sp)
     sw gp, __reg_gp__OFFSET(sp)
     sw tp, __reg_tp__OFFSET(sp)
@@ -305,22 +303,8 @@ rv32_exception_entry:
     la      t0,  k_curr_task
     la      t1,  k_next_task
 
-    beq     t0,  t1, irq_restore
-
-    sw s0, __reg_s0__OFFSET(sp)
-    sw s1, __reg_s1__OFFSET(sp)
-    sw s2, __reg_s2__OFFSET(sp)
-    sw s3, __reg_s3__OFFSET(sp)
-    sw s4, __reg_s4__OFFSET(sp)
-    sw s5, __reg_s5__OFFSET(sp)
-    sw s6, __reg_s6__OFFSET(sp)
-    sw s7, __reg_s7__OFFSET(sp)
-    sw s8, __reg_s8__OFFSET(sp)
-    sw s9, __reg_s9__OFFSET(sp)
-    sw s10, __reg_s10__OFFSET(sp)
-    sw s11, __reg_s11__OFFSET(sp)
-
-    j switch_task
+    // unlikely
+    bne     t0,  t1, irq_task_switch
 
 irq_restore:
     lw      t0,   __reg_mepc_OFFSET(sp)
@@ -350,3 +334,19 @@ irq_restore:
     addi    sp, sp, 128
 
     mret
+
+irq_task_switch:
+    sw s0, __reg_s0__OFFSET(sp)
+    sw s1, __reg_s1__OFFSET(sp)
+    sw s2, __reg_s2__OFFSET(sp)
+    sw s3, __reg_s3__OFFSET(sp)
+    sw s4, __reg_s4__OFFSET(sp)
+    sw s5, __reg_s5__OFFSET(sp)
+    sw s6, __reg_s6__OFFSET(sp)
+    sw s7, __reg_s7__OFFSET(sp)
+    sw s8, __reg_s8__OFFSET(sp)
+    sw s9, __reg_s9__OFFSET(sp)
+    sw s10, __reg_s10__OFFSET(sp)
+    sw s11, __reg_s11__OFFSET(sp)
+
+    j switch_task

--- a/arch/risc-v/rv32i/gcc/port_s.S
+++ b/arch/risc-v/rv32i/gcc/port_s.S
@@ -146,10 +146,6 @@ port_sched_start:
     lw      t0, (t0)                // t0 = &(k_curr_task->sp)
     lw      sp, (t0)                // sp = k_curr_task->sp
 
-    // save sp to stack
-    addi    t1, sp, 128
-    sw      t1, (t0)
-
     j       restore_context
 
 

--- a/arch/risc-v/spike/gcc/riscv_port.h
+++ b/arch/risc-v/spike/gcc/riscv_port.h
@@ -23,7 +23,7 @@
 #define CLINT_MTIMECMP  0x4000
 #define CLINT_MTIME     0xBFF8
 
-#define SOC_MCAUSE_EXP_MASK 0x7FFFFFFF
+#define MCAUSE_EXP_CODE_MASK 0x7FFFFFFF
 
 #ifndef __ASSEMBLER__
 void port_cpu_init();

--- a/board/GD32VF103C_START/TOS_CONFIG/tos_config.h
+++ b/board/GD32VF103C_START/TOS_CONFIG/tos_config.h
@@ -48,6 +48,9 @@
 // 配置TencentOS tiny空闲任务栈大小
 #define TOS_CFG_IDLE_TASK_STK_SIZE 512u
 
+// 配置TencentOS tiny中断栈大小
+#define TOS_CFG_IRQ_STK_SIZE 128u
+
 // 配置TencentOS tiny的tick频率
 #define TOS_CFG_CPU_TICK_PER_SECOND 1000u
 

--- a/board/QEMU_Spike/TOS-CONFIG/tos_config.h
+++ b/board/QEMU_Spike/TOS-CONFIG/tos_config.h
@@ -43,5 +43,6 @@
 
 #define TOS_CFG_MMBLK_EN 1u
 
+#define TOS_CFG_IRQ_STK_SIZE 128u
 
 #endif /* INC_TOS_CONFIG_H_ */


### PR DESCRIPTION
1.  添加中断栈，进一步节省任务需要预留的栈空间
2. 修复没有save & restore寄存器`x1`的bug
3. 调整`irq_restore`和`irq_task_switch`的顺序，因为`irq_restore`更频繁地执行，调整顺序可以减少流水线失效的情况