### PR TITLE
linux port更新

### DIFF
--- a/arch/linux/common/tos_cpu.c
+++ b/arch/linux/common/tos_cpu.c
@@ -78,6 +78,7 @@ __API__ void tos_cpu_cpsr_restore(cpu_cpsr_t cpsr)
 
 __KERNEL__ void cpu_init(void)
 {
+    port_init();
     k_cpu_cycle_per_tick = TOS_CFG_CPU_CLOCK / k_cpu_tick_per_second;
     cpu_systick_init(k_cpu_cycle_per_tick);
 
@@ -108,7 +109,6 @@ __KERNEL__ void cpu_irq_context_switch(void)
 
 __KERNEL__ void cpu_systick_init(k_cycle_t cycle_per_tick)
 {
-    port_systick_priority_set(TOS_CFG_CPU_SYSTICK_PRIO);
     port_systick_config(cycle_per_tick);
 }
 

--- a/arch/linux/posix/gcc/port.c
+++ b/arch/linux/posix/gcc/port.c
@@ -133,12 +133,6 @@ __PORT__ pthread_t  port_create_thread(void *arg)
 
 __PORT__ void port_sched_start(void) 
 {
-    main_thread_id = pthread_self();
-    pthread_mutex_init(&cpsr_mutex,NULL);
-    _install_signal(SIG_SUSPEND, _handle_suspend_thread);
-    _install_signal(SIG_RESUME, _handle_resume_thread);
-    _install_signal(SIG_CONTEXT_SWITCH, _handle_context_switch);
-
     k_curr_task = k_next_task;
     _resume_task(k_curr_task);
 
@@ -193,8 +187,13 @@ __PORT__ void port_systick_config(uint32_t cycle_per_tick)
 	}
 }
 
-__PORT__ void port_systick_priority_set(uint32_t prio)
+__PORT__ void port_init(void)
 {
+    main_thread_id = pthread_self();
+    pthread_mutex_init(&cpsr_mutex,NULL);
+    _install_signal(SIG_SUSPEND, _handle_suspend_thread);
+    _install_signal(SIG_RESUME, _handle_resume_thread);
+    _install_signal(SIG_CONTEXT_SWITCH, _handle_context_switch);
 }
 
 __PORT__ void port_delay_ms(uint32_t ms) 

--- a/arch/linux/posix/gcc/port.h
+++ b/arch/linux/posix/gcc/port.h
@@ -89,7 +89,7 @@ __PORT__ void       port_irq_context_switch(void);
 
 __PORT__ void       port_systick_config(uint32_t cycle_per_tick);
 
-__PORT__ void       port_systick_priority_set(uint32_t prio);  //ok
+__PORT__ void       port_init(void);
 
 __PORT__ pthread_t  port_create_thread(void *arg);
 


### PR DESCRIPTION
1. 进入临界区添加互斥锁
2. socket接口使用信号代替轮询