### PR TITLE
LoRa Demo 的上报周期单位调整为秒

### DIFF
--- a/examples/LoRaWAN/lora_demo.c
+++ b/examples/LoRaWAN/lora_demo.c
@@ -51,7 +51,7 @@
 
  */
 
-uint16_t report_period = 3000;
+uint16_t report_period = 10;
 
 typedef struct device_data_st {
     uint8_t     temperature;
@@ -110,7 +110,7 @@ void application_entry(void *arg)
         dev_data_wrapper.u.dev_data.period      = report_period;
 
         tos_lora_module_send(dev_data_wrapper.u.serialize, sizeof(dev_data_t));
-        tos_task_delay(report_period);
+        tos_task_delay(report_period * 1000);
     }
 }
 


### PR DESCRIPTION
与 @daishengdong  交流，将 LoRa Demo 做点微调，上报周期单位调整为秒