### PR TITLE
fixed the array length error of RHF76.c

### DIFF
--- a/devices/rhf76_lora/RHF76.c
+++ b/devices/rhf76_lora/RHF76.c
@@ -355,7 +355,7 @@ __STATIC__ void rhf76_incoming_data_process(void)
 
     ret = 0;
 
-    memset(incoming_data_buffer, 0x00, 512);
+    memset(incoming_data_buffer, 0x00, sizeof(incoming_data_buffer));
 
     while (1) {
         tos_at_uart_read(&data, 1);


### PR DESCRIPTION
1.__STATIC__ char incoming_data_buffer[128];  but in function  memset(incoming_data_buffer, 0x00, 512); define is 128, memset is 512.
2. so we fixed this replace with 'sizeof(incoming_data_buffer)', just like this 'memset(incoming_data_buffer, 0x00, sizeof(incoming_data_buffer));'