### PR TITLE
[bug] fixed in sim7600ce.c

### DIFF
--- a/devices/sim7600ce/sim7600ce.c
+++ b/devices/sim7600ce/sim7600ce.c
@@ -48,7 +48,7 @@ static int sim7600ce_signal_quality_check(void)
 
     str = strstr(echo.buffer, "+CSQ:");
     sscanf(str, "+CSQ:%d,%d", &rssi, &ber);
-    if (rssi == 99 || ber != 99) {
+    if (rssi == 99 || ber == 99) {
         return -1;
     }
 


### PR DESCRIPTION
1. if (rssi == 99 || ber != 99) {
        return -1;
    }
this is a bug, as datasheet show, value 99 means 'not known or not detectable', so it should been fixed as below:
    if (rssi == 99 || ber == 99) {
        return -1;
    }