### PR TITLE
Minor optimisation to the tcp_client code

### DIFF
--- a/examples/tcp_udp_base_lwip/tcp_client/tcp_client.c
+++ b/examples/tcp_udp_base_lwip/tcp_client/tcp_client.c
@@ -38,7 +38,7 @@ void application_entry(void *arg)
 
         printf("send(%d): %s:%d :%s\n", ++cnt, server_ip, server_port, str);
         if ((send(socketfd, str, strlen(str), 0)) < 0) {
-            printf("send mes error: %s errno : %d\n", strerror(errno), errno);
+            printf("send msg error: %s errno : %d\n", strerror(errno), errno);
             goto tcp_client_exit;
         }
 


### PR DESCRIPTION
This is minor optimisation to the tcp_client code:

Note that two lines, one is 'send mes error', the other is 'recv msg from server', 
the first 'mes' should be 'msg', for short. The code is more readable.