### PR TITLE
Minor optimisation to the tcp_server code

### DIFF
--- a/examples/tcp_udp_base_lwip/tcp_server/tcp_server.c
+++ b/examples/tcp_udp_base_lwip/tcp_server/tcp_server.c
@@ -51,7 +51,7 @@ void application_entry(void *arg)
         buff[n] = '\0';
         printf("recv(%d) msg from client:%s\n", ++cnt, buff);
         if ((send(connfd, buff, strlen(buff), 0)) < 0) {
-            printf("send mes error: %s errno : %d\n", strerror(errno), errno);
+            printf("send msg error: %s errno : %d\n", strerror(errno), errno);
             break;
         }
         close(connfd);


### PR DESCRIPTION
This is minor optimisation to the tcp_server code:

Note that two lines, one is 'recv(%d) msg from client', the other is 'send mes error',
the second 'mes' should be 'msg', for short. The code is more readable.