### PR TITLE
Minor optimisation to the fatfs_sample code

### DIFF
--- a/examples/fatfs/fatfs_sample.c
+++ b/examples/fatfs/fatfs_sample.c
@@ -51,7 +51,5 @@ void application_entry(void *arg)
         printf("read error: %d\n", res);
     }
     f_close(&file);
-
-    f_sync(&file);
 }
 


### PR DESCRIPTION
This is minor optimisation to the fatfs_sample code:

Note that end of this code:
f_close(&file);
f_sync(&file);
the second step 'f_sync(&file)' can be deleted, because in ff.c,
the function 'f_close' contain the  function 'f_sync':
#if !FF_FS_READONLY
	res = f_sync(fp);					/* Flush cached data */
	if (res == FR_OK)
#endif

in ffconf.h  has such define as below:
#define FF_FS_READONLY	0