### PR TITLE
Fixed wrong timer in radio

### DIFF
--- a/components/connectivity/LoraWAN/radio/sx126x/radio.c
+++ b/components/connectivity/LoraWAN/radio/sx126x/radio.c
@@ -968,8 +968,8 @@ void RadioSetTxContinuousWave( uint32_t freq, int8_t power, uint16_t time )
     SX126xSetRfTxPower( power );
     SX126xSetTxContinuousWave( );
 
-    TimerSetValue( &RxTimeoutTimer, time  * 1e3 );
-    TimerStart( &RxTimeoutTimer );
+    TimerSetValue( &TxTimeoutTimer, time  * 1e3 );
+    TimerStart( &TxTimeoutTimer );
 }
 
 int16_t RadioRssi( RadioModems_t modem )


### PR DESCRIPTION
Note that it is a tx function named RadioSetTxContinuousWave, 
so the timer 'RxTimeoutTimer' should been replaced with 'TxTimeoutTimer'.