### PR TITLE
Fixed typo: 'lenght' in qclould-iot-hub-sdk

### DIFF
--- a/components/connectivity/qcloud-iot-hub-sdk-3.1.2/3rdparty/sdk_src/internal_inc/utils_md5.h
+++ b/components/connectivity/qcloud-iot-hub-sdk-3.1.2/3rdparty/sdk_src/internal_inc/utils_md5.h
@@ -81,7 +81,7 @@ void utils_md5_process(iot_md5_context *ctx, const unsigned char data[64]);
  * @brief          Output = MD5( input buffer )
  *
  * @param input    data input
- * @param ilen     data lenght
+ * @param ilen     data length
  * @param output   MD5 result
  */
 void utils_md5(const unsigned char *input, size_t ilen, unsigned char output[16]);


### PR DESCRIPTION
Note that the word 'lenght' is wrong,
so that 'lenght' should been replaced with 'length'.