### PR TITLE
Fixed typo 'swich' in port_s.S

### DIFF
--- a/arch/arm/arm-v7m/cortex-m4/armcc/port_s.S
+++ b/arch/arm/arm-v7m/cortex-m4/armcc/port_s.S
@@ -64,7 +64,7 @@ port_sched_start
     CPSID   I
 
     ; set pendsv priority lowest
-    ; otherwise trigger pendsv in port_irq_context_switch will cause a context swich in irq
+    ; otherwise trigger pendsv in port_irq_context_switch will cause a context switch in irq
     ; that would be a disaster
     MOV32   R0, NVIC_SYSPRI14
     MOV32   R1, NVIC_PENDSV_PRI

--- a/arch/arm/arm-v7m/cortex-m4/gcc/port_s.S
+++ b/arch/arm/arm-v7m/cortex-m4/gcc/port_s.S
@@ -66,7 +66,7 @@ port_sched_start:
     CPSID   I
 
     @ set pendsv priority lowest
-    @ otherwise trigger pendsv in port_irq_context_switch will cause a context swich in irq
+    @ otherwise trigger pendsv in port_irq_context_switch will cause a context switch in irq
     @ that would be a disaster
     MOVW    R0, #:lower16:NVIC_SYSPRI14
     MOVT    R0, #:upper16:NVIC_SYSPRI14

--- a/arch/arm/arm-v7m/cortex-m4/iccarm/port_s.S
+++ b/arch/arm/arm-v7m/cortex-m4/iccarm/port_s.S
@@ -56,7 +56,7 @@ port_sched_start
     CPSID   I
 
     ; set pendsv priority lowest
-    ; otherwise trigger pendsv in port_irq_context_switch will cause a context swich in irq
+    ; otherwise trigger pendsv in port_irq_context_switch will cause a context switch in irq
     ; that would be a disaster
     MOV32   R0, NVIC_SYSPRI14
     MOV32   R1, NVIC_PENDSV_PRI

--- a/arch/arm/arm-v7m/cortex-m7/armcc/port_s.S
+++ b/arch/arm/arm-v7m/cortex-m7/armcc/port_s.S
@@ -64,7 +64,7 @@ port_sched_start
     CPSID   I
 
     ; set pendsv priority lowest
-    ; otherwise trigger pendsv in port_irq_context_switch will cause a context swich in irq
+    ; otherwise trigger pendsv in port_irq_context_switch will cause a context switch in irq
     ; that would be a disaster
     MOV32   R0, NVIC_SYSPRI14
     MOV32   R1, NVIC_PENDSV_PRI

--- a/arch/arm/arm-v7m/cortex-m7/gcc/port_s.S
+++ b/arch/arm/arm-v7m/cortex-m7/gcc/port_s.S
@@ -66,7 +66,7 @@ port_sched_start:
     CPSID   I
 
     @ set pendsv priority lowest
-    @ otherwise trigger pendsv in port_irq_context_switch will cause a context swich in irq
+    @ otherwise trigger pendsv in port_irq_context_switch will cause a context switch in irq
     @ that would be a disaster
     MOVW    R0, #:lower16:NVIC_SYSPRI14
     MOVT    R0, #:upper16:NVIC_SYSPRI14

--- a/arch/arm/arm-v7m/cortex-m7/iccarm/port_s.S
+++ b/arch/arm/arm-v7m/cortex-m7/iccarm/port_s.S
@@ -56,7 +56,7 @@ port_sched_start
     CPSID   I
 
     ; set pendsv priority lowest
-    ; otherwise trigger pendsv in port_irq_context_switch will cause a context swich in irq
+    ; otherwise trigger pendsv in port_irq_context_switch will cause a context switch in irq
     ; that would be a disaster
     MOV32   R0, NVIC_SYSPRI14
     MOV32   R1, NVIC_PENDSV_PRI

--- a/arch/arm/arm-v7m/cortex-m7/iccarm/port_s.S
+++ b/arch/arm/arm-v7m/cortex-m7/iccarm/port_s.S
@@ -56,7 +56,7 @@ port_sched_start
     CPSID   I
 
     ; set pendsv priority lowest
-    ; otherwise trigger pendsv in port_irq_context_switch will cause a context switch in irq
+    ; otherwise trigger pendsv in port_irq_context_switch will cause a context swich in irq
     ; that would be a disaster
     MOV32   R0, NVIC_SYSPRI14
     MOV32   R1, NVIC_PENDSV_PRI


### PR DESCRIPTION
typo error: swich -> switch