### PR TITLE
Fixed typo 'context-swith' in tos_evtdrv_sys.h

### DIFF
--- a/kernel/evtdrv/include/tos_evtdrv_sys.h
+++ b/kernel/evtdrv/include/tos_evtdrv_sys.h
@@ -25,7 +25,7 @@ typedef void (*k_evtdrv_poll_t)(void);
 /**
  * @brief Initialize the event-driven system.
  *
- * @attention event-driven is a simplified schedule model to support the none-context-swith-based multi-task programming.("the big while 1")
+ * @attention event-driven is a simplified schedule model to support the none-context-switch-based multi-task programming.("the big while 1")
  * must enable TOS_CFG_MMHEAP_EN to use event-driven.
  *
  * @param[in]   tasks               array of the tasks.


### PR DESCRIPTION
'context-switch' is right, so we should re-code:
none-context-swith-based -> none-context-switch-based