### PR TITLE
Fixed  stackover flow bug in qcloud_json_token.c

### DIFF
--- a/components/connectivity/TencentCloud_SDK/source/src/utils/qcloud_json_token.c
+++ b/components/connectivity/TencentCloud_SDK/source/src/utils/qcloud_json_token.c
@@ -109,6 +109,9 @@ list_head_t *LITE_json_keys_of(char *src, char *prefix)
             json_key_t     *entry = NULL;
 
             entry = osal_malloc(sizeof(json_key_t));
+            if (NULL == entry) {
+                return NULL;
+            }
             memset(entry, 0, sizeof(json_key_t));
             entry->key = LITE_format_string("%s%.*s", prefix, klen, key);
             list_add_tail(&entry->list, &keylist);
@@ -127,6 +130,9 @@ list_head_t *LITE_json_keys_of(char *src, char *prefix)
         json_key_t     *entry = NULL;
 
         entry = osal_malloc(sizeof(json_key_t));
+        if (NULL == entry) {
+            return NULL;
+        }
         memset(entry, 0, sizeof(json_key_t));
         list_add_tail(&entry->list, &keylist);
 

--- a/components/connectivity/TencentCloud_SDK/source/src/utils/qcloud_string_utils.c
+++ b/components/connectivity/TencentCloud_SDK/source/src/utils/qcloud_string_utils.c
@@ -29,6 +29,10 @@ char *LITE_format_string(const char *fmt, ...)
 
     va_start(ap, fmt);
     tmp = osal_malloc(TEMP_STRING_MAXLEN);
+    if(NULL == tmp)
+    {
+        return NULL;
+    }
     memset(tmp, 0, TEMP_STRING_MAXLEN);
     rc = osal_vsnprintf(tmp, TEMP_STRING_MAXLEN, fmt, ap);
     va_end(ap);
@@ -52,6 +56,10 @@ char *LITE_format_nstring(const int len, const char *fmt, ...)
 
     va_start(ap, fmt);
     tmp = osal_malloc(len+2);
+    if(NULL == tmp)
+    {
+        return NULL;
+    }
     memset(tmp, 0, len+2);
     rc = osal_vsnprintf(tmp, len+1, fmt, ap);
     va_end(ap);


### PR DESCRIPTION
Add if ‘NULL’：
```
            if (NULL == entry) {
                return NULL;
            }
```