### PR TITLE
enable the device to send unconfirmed message for RHF76...

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -32,5 +32,5 @@ board/*/MDK-ARM/*.uvguix.*
 board/*/MDK-ARM/EventRecorderStub.scvd
 board/*/MDK-ARM/*/*.htm
 board/*/MDK-ARM/*/*.build_log.htm
-Obj/*
-Debug/*
+board/**/Debug/*
+board/**/settings/*

--- a/devices/rhf76_lora/RHF76.c
+++ b/devices/rhf76_lora/RHF76.c
@@ -154,6 +154,26 @@ static int rhf76_set_chanel(void)
     return -1;
 }
 
+static int rhf76_set_repeat(uint8_t num)
+{
+    int try = 0;
+    at_echo_t echo;
+    char cmd[14] = {0};
+    char expect[10] = {'\0'};
+    snprintf(cmd, sizeof(cmd), RHF76_ATCMD_SET_REPT, num);
+    snprintf(expect, sizeof(expect), "+REPT: %d", num);
+    
+    tos_at_echo_create(&echo, NULL, 0, expect);
+
+    while (try++ < 10) {
+        tos_at_cmd_exec(&echo, 3000, cmd);
+        if (echo.status == AT_ECHO_STATUS_OK || echo.status == AT_ECHO_STATUS_EXPECT) {
+            return 0;
+        }
+    }
+    return -1;
+}
+
 static int rhf76_set_adr_off(void)
 {
     int try = 0;
@@ -305,9 +325,14 @@ static int rhf76_init(void)
         return -1;
     }
 
+    if(rhf76_set_repeat(1)!=0){
+        printf("rhf76 set repeat times for unconfirmed message FAILED\n");
+        return -1;
+    }
+    
     at_delay_ms(2000);
     printf("Init RHF76 LoRa done\n");
-
+    
     return 0;
 }
 
@@ -377,6 +402,7 @@ __STATIC__ void rhf76_incoming_data_process(void)
 
 at_event_t rhf76_at_event[] = {
     { "+CMSGHEX: PORT:", rhf76_incoming_data_process },
+    { "+MSGHEX: PORT:", rhf76_incoming_data_process }
 };
 
 static char __num2hex(uint8_t num)
@@ -405,7 +431,6 @@ static void __hex2str(uint8_t *in, char *out, int len)
 
 static int rhf76_send(const void *buf, size_t len)
 {
-
     char *str_buf = NULL;
 
     str_buf = tos_mmheap_calloc(2 * len + 1, sizeof(char));
@@ -416,10 +441,34 @@ static int rhf76_send(const void *buf, size_t len)
 
     char cmd[100] = {0};
     at_echo_t echo;
-    snprintf(cmd, sizeof(cmd), RHF76_ATCMD_FMT_SEND_MSGHEX, str_buf);
+    snprintf(cmd, sizeof(cmd), RHF76_ATCMD_FMT_SEND_CMSGHEX, str_buf);
     cmd[sizeof(cmd) - 1] = '\0';
     tos_mmheap_free(str_buf);
     tos_at_echo_create(&echo, NULL, 0, "+CMSG: ACK Received");
+    tos_at_cmd_exec(&echo, 6000, cmd);
+    if (echo.status == AT_ECHO_STATUS_OK || echo.status == AT_ECHO_STATUS_EXPECT) {
+        return -1;
+    }
+    return len;
+}
+
+static int rhf76_send_unconfirmed(const void *buf, size_t len)
+{
+
+    char *str_buf = NULL;
+    at_echo_t echo;
+
+    str_buf = tos_mmheap_calloc(2 * len + 1, sizeof(char));
+    if (!str_buf) {
+        return -1;
+    }
+    __hex2str((uint8_t *)buf, str_buf, len);
+
+    char cmd[100] = {0};
+    snprintf(cmd, sizeof(cmd), RHF76_ATCMD_FMT_SEND_MSGHEX, str_buf);
+    cmd[sizeof(cmd) - 1] = '\0';
+    tos_mmheap_free(str_buf);
+    tos_at_echo_create(&echo, NULL, 0, "+MSGHEX: Done");
     tos_at_cmd_exec(&echo, 6000, cmd);
     if (echo.status == AT_ECHO_STATUS_OK || echo.status == AT_ECHO_STATUS_EXPECT) {
         return -1;
@@ -433,12 +482,13 @@ static int rhf76_close(void)
 }
 
 lora_module_t lora_module_rhf76 = {
-    .init           = rhf76_init,
-    .join_otaa      = rhf76_join_otaa,
-    .join_abp       = rhf76_join_abp,
-    .send           = rhf76_send,
-    .close          = rhf76_close,
-    .recv_callback  = K_NULL,
+    .init             = rhf76_init,
+    .join_otaa        = rhf76_join_otaa,
+    .join_abp         = rhf76_join_abp,
+    .send             = rhf76_send,
+    .send_unconfirmed = rhf76_send_unconfirmed,
+    .close            = rhf76_close,
+    .recv_callback    = K_NULL,
 };
 
 int rhf76_lora_init(hal_uart_port_t uart_port)

--- a/devices/rhf76_lora/RHF76.h
+++ b/devices/rhf76_lora/RHF76.h
@@ -65,7 +65,10 @@ typedef enum lora_key_type {
 #define RHF76_ATCMD_FMT_SET_KEY_TYPE_APPKEY     "AT+KEY=\"appkey\",%s\r\n"
 #define RHF76_ATCMD_FMT_SET_KEY_TYPE_APPSKEY    "AT+KEY=\"appskey\",%s\r\n"
 #define RHF76_ATCMD_FMT_SET_KEY_TYPE_NWKSKEY    "AT+KEY=\"nwkskey\",%s\r\n"
-#define RHF76_ATCMD_FMT_SEND_MSGHEX             "AT+CMSGHEX=\"%s\"\r\n"
+#define RHF76_ATCMD_FMT_SEND_CMSGHEX            "AT+CMSGHEX=\"%s\"\r\n"
+#define RHF76_ATCMD_FMT_SEND_MSGHEX             "AT+MSGHEX=\"%s\"\r\n"
+
+#define RHF76_ATCMD_SET_REPT                    "AT+REPT=%d\r\n"
 
 #define RHF76_ATCMD_SET_BAND_CN470              "AT+DR=CN470\r\n"
 #define RHF76_ATCMD_REPLY_BAND_CN470            "+DR: CN470"

--- a/net/lora_module_wrapper/lora_module_wrapper.c
+++ b/net/lora_module_wrapper/lora_module_wrapper.c
@@ -44,6 +44,14 @@ int tos_lora_module_send(const void *buf, size_t len)
     return -1;
 }
 
+int tos_lora_module_send_unconfirmed(const void *buf, size_t len)
+{
+    if (g_lora_module && g_lora_module->send_unconfirmed) {
+        return g_lora_module->send_unconfirmed(buf, len);
+    }
+    return -1;
+}
+
 int tos_lora_module_recvcb_register(lora_recv_callback_t recv_callback)
 {
     if (g_lora_module) {

--- a/net/lora_module_wrapper/lora_module_wrapper.h
+++ b/net/lora_module_wrapper/lora_module_wrapper.h
@@ -32,6 +32,8 @@ typedef struct lora_module_st {
 
     int (*send)(const void *buf, size_t len);
 
+    int (*send_unconfirmed)(const void *buf, size_t len);
+    
     int (*close)(void);
 
     lora_recv_callback_t recv_callback;
@@ -86,6 +88,18 @@ int tos_lora_module_join_abp(const char *deveui, const char *devaddr, const char
  * @return  errcode
  */
 int tos_lora_module_send(const void *buf, size_t len);
+
+/**
+ * @brief Send unconfirmed data (message) by lora module.
+ *
+ * @attention None
+ *
+ * @param[in]   buf     data to send
+ * @param[in]   len     length of the data
+ *
+ * @return  errcode
+ */
+int tos_lora_module_send_unconfirmed(const void *buf, size_t len);
 
 /**
  * @brief Register a Receive callback method by lora module.


### PR DESCRIPTION
1. added "AT+MSGHEX" and "AT+REPT" commands, and change the original RHF76_ATCMD_FMT_SEND_MSGHEX to RHF76_ATCMD_FMT_SEND_CMSGHEX as by default the device only send the confirmed message.

2.  in order to follow the "non-breaking" pattern, 
   2.1 following functions are implemented:
          tos_lora_module_send_unconfirmed
          rhf76_send_unconfirmed
   2.2 a new event handle (*send_unconfirmed) is added to lora_module_st
   2.3 at event { "+MSGHEX: PORT:", rhf76_incoming_data_process } is added to rhf76_at_event, so it could handle the downlink data when the device opens RX1 window after sending a unconfirmed message.

3. modified the example lora_demo for the board NUCLEO_STM32L073RZ, which allows user to change magnetometer fullscale/sending confirmed or unconfirmed message/report period from the Tencent IoT development platform over the air.  
    