### PR TITLE
added reading internal flash functions for stm32l0xx series

### DIFF
--- a/board/NUCLEO_STM32L073RZ/BSP/HardWare/Common/bsp.c
+++ b/board/NUCLEO_STM32L073RZ/BSP/HardWare/Common/bsp.c
@@ -3,19 +3,20 @@
   * @file    bsp.c
   * @author  jieranzhi
   * @brief   provide high level interfaces to manage the sensors on the 
-  *          application, this is a modified version of the official api
+  *          application
   ******************************************************************************
   */
 
 /* Includes ------------------------------------------------------------------*/
 #include "bsp.h"
 
-void  BSP_Sensor_Init(void)
+void  BSP_Sensor_Init(DeviceConfig_TypeDef config)
 {
   /* Initialize sensors */
   HTS221_Init();
   LPS22HB_Init();
   LIS3MDL_Init();
+  LIS3MDL_Set_FullScale((LIS3MDL_FullScaleTypeDef)config.magn_fullscale);
 }
 
 void BSP_Sensor_Read(sensor_data_t *sensor_data)

--- a/board/NUCLEO_STM32L073RZ/BSP/HardWare/Common/bsp.c
+++ b/board/NUCLEO_STM32L073RZ/BSP/HardWare/Common/bsp.c
@@ -17,6 +17,9 @@ void  BSP_Sensor_Init(DeviceConfig_TypeDef config)
   LPS22HB_Init();
   LIS3MDL_Init();
   LIS3MDL_Set_FullScale((LIS3MDL_FullScaleTypeDef)config.magn_fullscale);
+  LSM6DS3_Init();
+  LSM6DS3_Set_Accel_FullScale((LSM6DS3_AccelFullscaleTypeDef)config.accel_fullscale);
+  LSM6DS3_Set_Gyro_FullScale((LSM6DS3_GyroFullscaleTypeDef)config.gyro_fullscale);
 }
 
 void BSP_Sensor_Read(sensor_data_t *sensor_data)

--- a/board/NUCLEO_STM32L073RZ/BSP/HardWare/Common/bsp.h
+++ b/board/NUCLEO_STM32L073RZ/BSP/HardWare/Common/bsp.h
@@ -20,6 +20,7 @@ extern "C" {
 #include "HTS221.h"
 #include "LPS22HB.h"
 #include "LIS3MDL.h"
+#include "LSM6DS3.h"
   
 /* Exported types ------------------------------------------------------------*/
 typedef struct
@@ -27,35 +28,31 @@ typedef struct
   sensor_press_t       sensor_press;         /* pressure sensor          */
   sensor_tempnhumi_t   sensor_tempnhumi;     /* temperature and humidity */
   sensor_magn_t        sensor_magn;          /* magnetometer             */
-  
-  //--------------------------- accelerator and gyroscope  -------------------//
-  int16_t  accel_x;                           /* in g           */
-  int16_t  accel_y;                           /* in g           */
-  int16_t  accel_z;                           /* in g           */
-  int16_t  gyro_x;                            /* in degree/s    */
-  int16_t  gyro_y;                            /* in degree/s    */
-  int16_t  gyro_z;                            /* in degree/s    */
-  
+  sensor_motion_t      sensor_motion;        /* accelerometer, gyroscope */
 } sensor_data_t;
 
  // application configuration types
  typedef enum{
-   DCT_IS_CONFIRM     = 0x00U,
-   DCT_REPORT_PERIOD  = 0x01U,
-   DCT_REPEAT_TIME    = 0x02U,
-   DCT_MAGN_FULLSCALE = 0x03U,
-   DCT_DEFAULT        = 0xFFU,
+   DCT_IS_CONFIRM      = 0x00U,
+   DCT_REPORT_PERIOD   = 0x01U,
+   DCT_REPEAT_TIME     = 0x02U,
+   DCT_MAGN_FULLSCALE  = 0x03U,
+   DCT_ACCEL_FULLSCALE = 0x04U,
+   DCT_GYRO_FULLSCALE  = 0x05U,
+   DCT_DEFAULT         = 0xFFU,
  }DeviceConfigType_TypeDef;
 
 // application configuration
 typedef struct
 {
-  uint32_t                  config_address;
-  uint16_t                  report_period;
-  uint8_t                   repeat_time;
-  LIS3MDL_FullScaleTypeDef  magn_fullscale;
-  bool                      is_confirmed;
-}DeviceConfig_TypeDef;
+  uint32_t                        config_address;
+  uint16_t                        report_period;
+  uint8_t                         repeat_time;
+  LIS3MDL_FullScaleTypeDef        magn_fullscale;
+  LSM6DS3_AccelFullscaleTypeDef   accel_fullscale;
+  LSM6DS3_GyroFullscaleTypeDef    gyro_fullscale;    
+  bool                            is_confirmed;
+}DeviceConfig_TypeDef;  
 
 /* Exported constants --------------------------------------------------------*/
 /* External variables --------------------------------------------------------*/

--- a/board/NUCLEO_STM32L073RZ/BSP/HardWare/Common/bsp.h
+++ b/board/NUCLEO_STM32L073RZ/BSP/HardWare/Common/bsp.h
@@ -1,33 +1,9 @@
-/*
- / _____)             _              | |
-( (____  _____ ____ _| |_ _____  ____| |__
- \____ \| ___ |    (_   _) ___ |/ ___)  _ \
- _____) ) ____| | | || |_| ____( (___| | | |
-(______/|_____)_|_|_| \__)_____)\____)_| |_|
-    (C)2013 Semtech
-
-Description: contains all hardware driver
-
-License: Revised BSD License, see LICENSE.TXT file include in the project
-
-Maintainer: Miguel Luis and Gregory Cristian
-*/
 /**
   ******************************************************************************
-  * @file    bsp.h
-  * @author  MCD Application Team
-  * @brief   contains all hardware driver
-  ******************************************************************************
-  * @attention
-  *
-  * <h2><center>&copy; Copyright (c) 2018 STMicroelectronics.
-  * All rights reserved.</center></h2>
-  *
-  * This software component is licensed by ST under Ultimate Liberty license
-  * SLA0044, the "License"; You may not use this file except in compliance with
-  * the License. You may obtain a copy of the License at:
-  *                             www.st.com/SLA0044
-  *
+  * @file    bsp.c
+  * @author  jieranzhi
+  * @brief   provide high level interfaces to manage the sensors on the 
+  *          application, this is a modified version of the official api
   ******************************************************************************
   */
 
@@ -40,6 +16,7 @@ extern "C" {
 #endif
 /* Includes ------------------------------------------------------------------*/
 #include <stdint.h>
+#include <stdbool.h>
 #include "HTS221.h"
 #include "LPS22HB.h"
 #include "LIS3MDL.h"
@@ -61,6 +38,25 @@ typedef struct
   
 } sensor_data_t;
 
+ // application configuration types
+ typedef enum{
+   DCT_IS_CONFIRM     = 0x00U,
+   DCT_REPORT_PERIOD  = 0x01U,
+   DCT_REPEAT_TIME    = 0x02U,
+   DCT_MAGN_FULLSCALE = 0x03U,
+   DCT_DEFAULT        = 0xFFU,
+ }DeviceConfigType_TypeDef;
+
+// application configuration
+typedef struct
+{
+  uint32_t                  config_address;
+  uint16_t                  report_period;
+  uint8_t                   repeat_time;
+  LIS3MDL_FullScaleTypeDef  magn_fullscale;
+  bool                      is_confirmed;
+}DeviceConfig_TypeDef;
+
 /* Exported constants --------------------------------------------------------*/
 /* External variables --------------------------------------------------------*/
 /* Exported macros -----------------------------------------------------------*/
@@ -71,7 +67,7 @@ typedef struct
  * @note
  * @retval None
  */
-void  BSP_Sensor_Init(void);
+void  BSP_Sensor_Init(DeviceConfig_TypeDef config);
 
 /**
  * @brief  sensor  read.

--- a/board/NUCLEO_STM32L073RZ/BSP/HardWare/LIS3MDL/LIS3MDL.c
+++ b/board/NUCLEO_STM32L073RZ/BSP/HardWare/LIS3MDL/LIS3MDL.c
@@ -75,19 +75,19 @@ uint16_t LIS3MDL_Get_Sensitivity(LIS3MDL_FullScaleTypeDef fullscale)
   uint16_t sensitivity = 1;
   switch(fullscale)
   {
-    case FULLSCALE_4:{
+    case MAGN_FULLSCALE_4:{
       sensitivity = 6842;
       break;
     }
-    case FULLSCALE_8:{
+    case MAGN_FULLSCALE_8:{
       sensitivity = 3421;
       break;
     }
-    case FULLSCALE_12:{
+    case MAGN_FULLSCALE_12:{
       sensitivity = 2281;
       break;
     }
-    case FULLSCALE_16:{
+    case MAGN_FULLSCALE_16:{
       sensitivity = 1711;
       break;
     }

--- a/board/NUCLEO_STM32L073RZ/BSP/HardWare/LIS3MDL/LIS3MDL.h
+++ b/board/NUCLEO_STM32L073RZ/BSP/HardWare/LIS3MDL/LIS3MDL.h
@@ -65,10 +65,10 @@ typedef enum
   */ 
 typedef enum
 {
-  FULLSCALE_4  = 0x00U,
-  FULLSCALE_8  = 0x01U,
-  FULLSCALE_12 = 0x02U,
-  FULLSCALE_16 = 0x03U
+  MAGN_FULLSCALE_4  = 0x00U,
+  MAGN_FULLSCALE_8  = 0x01U,
+  MAGN_FULLSCALE_12 = 0x02U,
+  MAGN_FULLSCALE_16 = 0x03U
 }LIS3MDL_FullScaleTypeDef;
 
 /** 

--- a/board/NUCLEO_STM32L073RZ/BSP/HardWare/LPS22HB/LPS22HB.h
+++ b/board/NUCLEO_STM32L073RZ/BSP/HardWare/LPS22HB/LPS22HB.h
@@ -58,7 +58,7 @@ typedef enum
 typedef struct
 {
   uint16_t sensitivity;                  // sensitivity per fullscale
-  uint32_t pressure;                       // X-magnetic value in LSB
+  uint32_t pressure;                     // pressure
 }sensor_press_t;
 
 /* Functions -----------------------------------------------------------------*/

--- a/board/NUCLEO_STM32L073RZ/BSP/HardWare/LSM6DS3/LSM6DS3.c
+++ b/board/NUCLEO_STM32L073RZ/BSP/HardWare/LSM6DS3/LSM6DS3.c
@@ -1,0 +1,359 @@
+/**
+  ******************************************************************************
+  * @file       LSM6DS3.c
+  * @author     jieranzhi
+  * @update     2020/03/23 19:00 CST
+  * @brief      This file provides code for the LSM6DS3 Initialization 
+  *             and data output codes.
+  ******************************************************************************
+  * @attention
+  *
+  * 1. this code is used as one of the examples in TencentOS_tiny project, it's 
+  *    just a simple implementation of the sensor functionalities, to implement 
+  *    more functions, please refer to the datasheet or the official software 
+  *    package provided by ST (STM32CubeExpansion_LRWAN_V1.3.1)
+  *
+  * 2. in this file the host MCU need to read the output persistently, which is 
+  *    not of power efficient, to achieve better power consumption performance,  
+  *    it is recommended to use FIFO.
+  *
+  ******************************************************************************
+  */
+
+#include <LSM6DS3.h>
+#include <i2c.h>
+
+// initialization of LSM6DS3
+void LSM6DS3_Init()
+{
+  uint8_t cmd = 0;
+
+  // ODR: 12.5Hz, fs: 4g, BWZ: 50Hz
+  cmd = 0x1B;
+  HAL_I2C_Mem_Write(&hi2c1, LSM6DS3_ADDR_WR, LSM6DS3_CTRL1_XL, I2C_MEMADD_SIZE_8BIT, &cmd, 1, 0xFFFF);
+  
+  // ODR: 12.5Hz, fs: 250dps
+  cmd = 0x10;
+  HAL_I2C_Mem_Write(&hi2c1, LSM6DS3_ADDR_WR, LSM6DS3_CTRL2_G, I2C_MEMADD_SIZE_8BIT, &cmd, 1, 0xFFFF);
+  
+  // High performance: disabled to save power 
+  cmd = 0x10;
+  HAL_I2C_Mem_Write(&hi2c1, LSM6DS3_ADDR_WR, LSM6DS3_CTRL6_C, I2C_MEMADD_SIZE_8BIT, &cmd, 1, 0xFFFF);
+  
+  // High performance: disabled to save power 
+  cmd = 0x80;
+  HAL_I2C_Mem_Write(&hi2c1, LSM6DS3_ADDR_WR, LSM6DS3_CTRL7_G, I2C_MEMADD_SIZE_8BIT, &cmd, 1, 0xFFFF);
+  
+  // timestamp output: enable, pedometer algorithm: enabled
+  cmd = 0xC0;
+  HAL_I2C_Mem_Write(&hi2c1, LSM6DS3_ADDR_WR, LSM6DS3_TAP_CFG, I2C_MEMADD_SIZE_8BIT, &cmd, 1, 0xFFFF);
+}
+
+void LSM6DS3_Set_Accel_FullScale(LSM6DS3_AccelFullscaleTypeDef fullscale)
+{
+  uint8_t ctrl_reg1_value;
+  uint8_t fullscale_config = (uint8_t)fullscale;
+  HAL_I2C_Mem_Read(&hi2c1, LSM6DS3_ADDR_RD, LSM6DS3_CTRL1_XL, I2C_MEMADD_SIZE_8BIT, &ctrl_reg1_value, 1, 0xFFFF);
+  fullscale_config = (ctrl_reg1_value&0xF1)|(fullscale_config&0x0E);
+  HAL_I2C_Mem_Write(&hi2c1, LSM6DS3_ADDR_WR, LSM6DS3_CTRL1_XL, I2C_MEMADD_SIZE_8BIT, &fullscale_config, 1, 0xFFFF);
+}
+
+void LSM6DS3_Set_Gyro_FullScale(LSM6DS3_GyroFullscaleTypeDef fullscale)
+{
+  uint8_t ctrl_reg2_value;
+  uint8_t fullscale_config = (uint8_t)fullscale;
+  HAL_I2C_Mem_Read(&hi2c1, LSM6DS3_ADDR_RD, LSM6DS3_CTRL2_G, I2C_MEMADD_SIZE_8BIT, &ctrl_reg2_value, 1, 0xFFFF);
+  fullscale_config = (ctrl_reg2_value&0xF1)|(fullscale_config&0x0E);
+  HAL_I2C_Mem_Write(&hi2c1, LSM6DS3_ADDR_WR, LSM6DS3_CTRL2_G, I2C_MEMADD_SIZE_8BIT, &fullscale_config, 1, 0xFFFF);
+}
+
+void LSM6DS3_Set_Accel_FullScale_Num(uint8_t fullscale_num)
+{
+  LSM6DS3_AccelFullscaleTypeDef fullscale = ACCEL_FULLSCALE_2;
+  switch(fullscale_num)
+  {  
+  case 2:
+    {
+      fullscale = ACCEL_FULLSCALE_2;
+      break;
+    }
+  case 16:
+    {
+      fullscale = ACCEL_FULLSCALE_16;
+      break;
+    }
+  case 4:
+    {
+      fullscale = ACCEL_FULLSCALE_4;
+      break;
+    }
+  case 8:
+    {
+      fullscale = ACCEL_FULLSCALE_8;
+      break;
+    }
+  default:
+    {
+      break;
+    }
+  }
+  LSM6DS3_Set_Accel_FullScale(fullscale);
+}
+
+void LSM6DS3_Set_Gyro_FullScale_Num(uint8_t fullscale_num)
+{  
+  LSM6DS3_GyroFullscaleTypeDef fullscale = GYRO_FULLSCALE_250;
+  switch(fullscale_num)
+  {  
+  case 125:
+    {
+      fullscale = GYRO_FULLSCALE_125;
+      break;
+    }
+  case 250:
+    {
+      fullscale = GYRO_FULLSCALE_250;
+      break;
+    }
+  case 500:
+    {
+      fullscale = GYRO_FULLSCALE_500;
+      break;
+    }
+  case 1000:
+    {
+      fullscale = GYRO_FULLSCALE_1000;
+      break;
+    }
+  case 2000:
+    {
+      fullscale = GYRO_FULLSCALE_2000;
+      break;
+    }
+  default:
+    {
+      break;
+    }
+  }
+  LSM6DS3_Set_Gyro_FullScale(fullscale);
+}
+
+uint8_t LSM6DS3_Get_Accel_FullScale_Num(LSM6DS3_AccelFullscaleTypeDef fullscale)
+{
+  uint8_t fullscale_num = 1;
+  switch(fullscale)
+  {  
+  case ACCEL_FULLSCALE_2:
+    {
+      fullscale_num = 2;
+      break;
+    }
+  case ACCEL_FULLSCALE_16:
+    {
+      fullscale_num = 16;
+      break;
+    }
+  case ACCEL_FULLSCALE_4:
+    {
+      fullscale_num = 4;
+      break;
+    }
+  case ACCEL_FULLSCALE_8:
+    {
+      fullscale_num = 8;
+      break;
+    }
+  default:
+    {
+      break;
+    }
+  }
+  return fullscale_num;
+}
+
+uint16_t LSM6DS3_Get_Gyro_FullScale_Num(LSM6DS3_GyroFullscaleTypeDef fullscale)
+{
+  uint16_t fullscale_num = 1;
+  switch(fullscale)
+  {  
+  case GYRO_FULLSCALE_125:
+    {
+      fullscale_num = 125;
+      break;
+    }
+  case GYRO_FULLSCALE_250:
+    {
+      fullscale_num = 250;
+      break;
+    }
+  case GYRO_FULLSCALE_500:
+    {
+      fullscale_num = 500;
+      break;
+    }
+  case GYRO_FULLSCALE_1000:
+    {
+      fullscale_num = 1000;
+      break;
+    }
+  case GYRO_FULLSCALE_2000:
+    {
+      fullscale_num = 2000;
+      break;
+    }
+  default:
+    {
+      break;
+    }
+  }
+  return fullscale_num;
+}
+
+LSM6DS3_AccelFullscaleTypeDef LSM6DS3_Get_Accel_FullScale()
+{
+  uint8_t fullscale;
+  HAL_I2C_Mem_Read(&hi2c1, LSM6DS3_ADDR_RD, LSM6DS3_CTRL1_XL, I2C_MEMADD_SIZE_8BIT, &fullscale, 1, 0xFFFF);
+  fullscale = (fullscale<<1)>>6;
+  return (LSM6DS3_AccelFullscaleTypeDef)fullscale;
+}
+
+LSM6DS3_GyroFullscaleTypeDef LSM6DS3_Get_Gyro_FullScale()
+{
+  uint8_t fullscale;
+  HAL_I2C_Mem_Read(&hi2c1, LSM6DS3_ADDR_RD, LSM6DS3_CTRL2_G, I2C_MEMADD_SIZE_8BIT, &fullscale, 1, 0xFFFF);
+  fullscale = fullscale&0x02;
+  if(fullscale == 0x00) fullscale = fullscale&0x0C;
+  return (LSM6DS3_GyroFullscaleTypeDef)fullscale;
+}
+
+uint16_t LSM6DS3_Get_Accel_Sensitivity(LSM6DS3_AccelFullscaleTypeDef fullscale)
+{
+  uint16_t sensitivity = 1;
+  switch(fullscale)
+  {
+    case ACCEL_FULLSCALE_2:{
+      sensitivity = 61;
+      break;
+    }
+    case ACCEL_FULLSCALE_4:{
+      sensitivity = 122;
+      break;
+    }
+    case ACCEL_FULLSCALE_8:{
+      sensitivity = 244;
+      break;
+    }
+    case ACCEL_FULLSCALE_16:{
+      sensitivity = 488;
+      break;
+    }
+    default:{
+      sensitivity = 1;
+    }
+  }
+  return sensitivity;
+}
+
+uint32_t LSM6DS3_Get_Gyro_Sensitivity(LSM6DS3_GyroFullscaleTypeDef fullscale)
+{
+  uint32_t sensitivity = 1;
+  switch(fullscale)
+  {
+    case GYRO_FULLSCALE_125:{
+      sensitivity = 4375;
+      break;
+    }
+    case GYRO_FULLSCALE_250:{
+      sensitivity = 8750;
+      break;
+    }
+    case GYRO_FULLSCALE_500:{
+      sensitivity = 17500;
+      break;
+    }
+    case GYRO_FULLSCALE_1000:{
+      sensitivity = 35000;
+      break;
+    }
+    case GYRO_FULLSCALE_2000:{
+      sensitivity = 70000;
+      break;
+    }
+    default:{
+      sensitivity = 1;
+    }
+  }
+  return sensitivity;
+}
+
+uint8_t LSM6DS3_Get_Sensor_Config(sensor_motion_t* sensor_motion)
+{
+  LSM6DS3_AccelFullscaleTypeDef accel_fullscale = LSM6DS3_Get_Accel_FullScale();
+  sensor_motion->accelFullscale = LSM6DS3_Get_Accel_FullScale_Num(accel_fullscale);
+  sensor_motion->accelSensitivity = LSM6DS3_Get_Accel_Sensitivity(accel_fullscale);
+  
+  LSM6DS3_GyroFullscaleTypeDef gyro_fullscale = LSM6DS3_Get_Gyro_FullScale();
+  sensor_motion->gyroFullscale = LSM6DS3_Get_Gyro_FullScale_Num(gyro_fullscale);
+  sensor_motion->gyroSensitivity = LSM6DS3_Get_Gyro_Sensitivity(gyro_fullscale);
+  
+  return 0;
+}
+
+uint8_t LSM6DS3_Get_Accel(sensor_motion_t* sensor_motion)
+{
+  uint8_t accelx_h, accelx_l, accely_h, accely_l, accelz_h, accelz_l;
+  uint8_t status_dat = 0;
+  
+  while((status_dat&LSM6DS3_XL_DA) != LSM6DS3_XL_DA)
+  {
+    HAL_I2C_Mem_Read(&hi2c1, LSM6DS3_ADDR_RD, LSM6DS3_STATUS_REG, I2C_MEMADD_SIZE_8BIT, &status_dat, 1, 0xFFFF);
+  }
+  
+  HAL_I2C_Mem_Read(&hi2c1, LSM6DS3_ADDR_RD, LSM6DS3_OUTX_H_XL, I2C_MEMADD_SIZE_8BIT, &accelx_h, 1, 0xFFFF);
+  HAL_I2C_Mem_Read(&hi2c1, LSM6DS3_ADDR_RD, LSM6DS3_OUTX_L_XL, I2C_MEMADD_SIZE_8BIT, &accelx_l, 1, 0xFFFF);
+  sensor_motion->accelX = (uint16_t)accelx_h<<8|accelx_l;
+  
+  HAL_I2C_Mem_Read(&hi2c1, LSM6DS3_ADDR_RD, LSM6DS3_OUTY_H_XL, I2C_MEMADD_SIZE_8BIT, &accely_h, 1, 0xFFFF);
+  HAL_I2C_Mem_Read(&hi2c1, LSM6DS3_ADDR_RD, LSM6DS3_OUTY_L_XL, I2C_MEMADD_SIZE_8BIT, &accely_l, 1, 0xFFFF);
+  sensor_motion->accelY = (uint16_t)accely_h<<8|accely_l;
+
+  HAL_I2C_Mem_Read(&hi2c1, LSM6DS3_ADDR_RD, LSM6DS3_OUTZ_H_XL, I2C_MEMADD_SIZE_8BIT, &accelz_h, 1, 0xFFFF);
+  HAL_I2C_Mem_Read(&hi2c1, LSM6DS3_ADDR_RD, LSM6DS3_OUTZ_L_XL, I2C_MEMADD_SIZE_8BIT, &accelz_l, 1, 0xFFFF);
+  sensor_motion->accelZ = (uint16_t)accelz_h<<8|accelz_l;
+  
+  return 0;
+}
+
+uint8_t LSM6DS3_Get_Gyro(sensor_motion_t* sensor_motion)
+{
+  uint8_t gyrox_h, gyrox_l, gyroy_h, gyroy_l, gyroz_h, gyroz_l;
+  uint8_t status_dat = 0;
+  
+  while((status_dat&LSM6DS3_G_DA) != LSM6DS3_G_DA)
+  {
+    HAL_I2C_Mem_Read(&hi2c1, LSM6DS3_ADDR_RD, LSM6DS3_STATUS_REG, I2C_MEMADD_SIZE_8BIT, &status_dat, 1, 0xFFFF);
+  }
+  
+  HAL_I2C_Mem_Read(&hi2c1, LSM6DS3_ADDR_RD, LSM6DS3_OUTX_H_G, I2C_MEMADD_SIZE_8BIT, &gyrox_h, 1, 0xFFFF);
+  HAL_I2C_Mem_Read(&hi2c1, LSM6DS3_ADDR_RD, LSM6DS3_OUTX_L_G, I2C_MEMADD_SIZE_8BIT, &gyrox_l, 1, 0xFFFF);
+  sensor_motion->gyroX = (uint16_t)gyrox_h<<8|gyrox_l;
+  
+  HAL_I2C_Mem_Read(&hi2c1, LSM6DS3_ADDR_RD, LSM6DS3_OUTY_H_G, I2C_MEMADD_SIZE_8BIT, &gyroy_h, 1, 0xFFFF);
+  HAL_I2C_Mem_Read(&hi2c1, LSM6DS3_ADDR_RD, LSM6DS3_OUTY_L_G, I2C_MEMADD_SIZE_8BIT, &gyroy_l, 1, 0xFFFF);
+  sensor_motion->gyroY = (uint16_t)gyroy_h<<8|gyroy_l;
+
+  HAL_I2C_Mem_Read(&hi2c1, LSM6DS3_ADDR_RD, LSM6DS3_OUTZ_H_G, I2C_MEMADD_SIZE_8BIT, &gyroz_h, 1, 0xFFFF);
+  HAL_I2C_Mem_Read(&hi2c1, LSM6DS3_ADDR_RD, LSM6DS3_OUTZ_L_G, I2C_MEMADD_SIZE_8BIT, &gyroz_l, 1, 0xFFFF);
+  sensor_motion->gyroZ = (uint16_t)gyroz_h<<8|gyroz_l;
+  
+  return 0;
+}
+
+uint8_t LSM6DS3_Get_Step(sensor_motion_t* sensor_motion)
+{
+  uint8_t step_h, step_l;
+  HAL_I2C_Mem_Read(&hi2c1, LSM6DS3_ADDR_RD, LSM6DS3_STEP_COUNTER_H, I2C_MEMADD_SIZE_8BIT, &step_h, 1, 0xFFFF);
+  HAL_I2C_Mem_Read(&hi2c1, LSM6DS3_ADDR_RD, LSM6DS3_STEP_COUNTER_L, I2C_MEMADD_SIZE_8BIT, &step_l, 1, 0xFFFF);
+  sensor_motion->stepCount = (uint16_t)step_h<<8|step_l;
+  return 0;
+}

--- a/board/NUCLEO_STM32L073RZ/BSP/HardWare/LSM6DS3/LSM6DS3.h
+++ b/board/NUCLEO_STM32L073RZ/BSP/HardWare/LSM6DS3/LSM6DS3.h
@@ -1,0 +1,130 @@
+/**
+  ******************************************************************************
+  * @file       LSM6DS3.h
+  * @author     jieranzhi (the developer)
+  * @update     2020/03/23 19:00 CST
+  * @brief      This file contains basic functions prototypes and pre-definitions 
+  *             of the register addresses
+  ******************************************************************************
+  * @attention
+  *
+  * 1. the temperature sensor embedded in the LSM6DS3 is intended to be embedded 
+  *    temperature compensation. Therefore, in this file we DO NOT include the
+  *    temperature output
+  *
+  * 2. on the P-NUCLEO-LRWAN3, the SDO/SA0 pad is connected to voltage supply(
+  *    via a resistor), LSb is ¡®1¡¯ (address 1011101b), and the sensor uses 
+  *    connection mode 1
+  *
+  * 3. for more information, please refer to the datasheet
+  *    (https://www.st.com/resource/en/datasheet/lsm6ds3.pdf)
+  *
+  ******************************************************************************
+  */ 
+#ifndef	_LSM6DS3_H_
+#define	_LSM6DS3_H_
+
+#include <stm32l0xx_hal.h>
+
+/* Registers -----------------------------------------------------------------*/
+#define LSM6DS3_ADDR_WR	        0xD6
+#define LSM6DS3_ADDR_RD	        0xD7
+
+#define LSM6DS3_CTRL1_XL        0x10
+#define LSM6DS3_CTRL2_G         0x11
+#define LSM6DS3_CTRL3_C         0x12
+#define LSM6DS3_CTRL4_C         0x13
+#define LSM6DS3_CTRL5_C         0x14
+#define LSM6DS3_CTRL6_C         0x15
+#define LSM6DS3_CTRL7_G         0x16
+#define LSM6DS3_CTRL8_XL        0x17
+#define LSM6DS3_CTRL9_XL        0x18
+#define LSM6DS3_CTRL10_C        0x19
+
+#define LSM6DS3_STATUS_REG	0x1E
+
+#define LSM6DS3_OUTX_L_G        0x22
+#define LSM6DS3_OUTX_H_G        0x23
+#define LSM6DS3_OUTY_L_G        0x24
+#define LSM6DS3_OUTY_H_G        0x25
+#define LSM6DS3_OUTZ_L_G        0x26
+#define LSM6DS3_OUTZ_H_G        0x27
+
+#define LSM6DS3_OUTX_L_XL       0x28
+#define LSM6DS3_OUTX_H_XL       0x29
+#define LSM6DS3_OUTY_L_XL       0x30
+#define LSM6DS3_OUTY_H_XL       0x31
+#define LSM6DS3_OUTZ_L_XL       0x32
+#define LSM6DS3_OUTZ_H_XL       0x33
+
+#define LSM6DS3_STEP_COUNTER_L  0x4B
+#define LSM6DS3_STEP_COUNTER_H  0x4C
+
+#define LSM6DS3_TAP_CFG         0x58
+
+
+
+/* Enumeration ---------------------------------------------------------------*/
+/** 
+  * @brief  STATUS structures definition  
+  */ 
+typedef enum
+{
+  LSM6DS3_T_DA  = 0x04,  /*!< temperature data available     */  
+  LSM6DS3_G_DA  = 0x02,  /*!< gyro data available            */
+  LSM6DS3_XL_DA = 0x01,  /*!< acceleration data available    */
+}LSM6DS3_StatusTypeDef;
+
+typedef enum
+{
+  ACCEL_FULLSCALE_2  = 0x00U,
+  ACCEL_FULLSCALE_16 = 0x04U,
+  ACCEL_FULLSCALE_4  = 0x08U,
+  ACCEL_FULLSCALE_8  = 0x0CU,
+}LSM6DS3_AccelFullscaleTypeDef;
+
+typedef enum
+{
+  GYRO_FULLSCALE_125  = 0x02U,
+  GYRO_FULLSCALE_250  = 0x00U,
+  GYRO_FULLSCALE_500  = 0x04U,
+  GYRO_FULLSCALE_1000 = 0x08U,
+  GYRO_FULLSCALE_2000 = 0x0CU,
+}LSM6DS3_GyroFullscaleTypeDef;
+
+/** 
+  * @brief  motion sensor structures definition  
+  */ 
+typedef struct
+{
+  uint8_t  accelFullscale;
+  uint8_t  gyroFullscale;
+  uint16_t accelSensitivity;  /*!< the sensitivity is 1000x its actual value */  
+  uint16_t gyroSensitivity;   /*!< the sensitivity is 1000x its actual value */  
+  uint16_t gyroX;
+  uint16_t gyroY;
+  uint16_t gyroZ;
+  uint16_t accelX;
+  uint16_t accelY;
+  uint16_t accelZ;
+  uint16_t stepCount;
+}sensor_motion_t;
+
+/* Functions -----------------------------------------------------------------*/
+void LSM6DS3_Init(void);
+void LSM6DS3_Set_Accel_FullScale(LSM6DS3_AccelFullscaleTypeDef fullscale);
+void LSM6DS3_Set_Gyro_FullScale(LSM6DS3_GyroFullscaleTypeDef fullscale);
+void LSM6DS3_Set_Accel_FullScale_Num(uint8_t fullscale_num);
+void LSM6DS3_Set_Gyro_FullScale_Num(uint8_t fullscale_num);
+uint8_t LSM6DS3_Get_Accel_FullScale_Num(LSM6DS3_AccelFullscaleTypeDef fullscale);
+uint16_t LSM6DS3_Get_Gyro_FullScale_Num(LSM6DS3_GyroFullscaleTypeDef fullscale);
+LSM6DS3_AccelFullscaleTypeDef LSM6DS3_Get_Accel_FullScale(void);
+LSM6DS3_GyroFullscaleTypeDef LSM6DS3_Get_Gyro_FullScale(void);
+uint16_t LSM6DS3_Get_Accel_Sensitivity(LSM6DS3_AccelFullscaleTypeDef fullscale);
+uint32_t LSM6DS3_Get_Gyro_Sensitivity(LSM6DS3_GyroFullscaleTypeDef fullscale);
+uint8_t LSM6DS3_Get_Sensor_Config(sensor_motion_t* sensor_motion);
+uint8_t LSM6DS3_Get_Accel(sensor_motion_t* sensor_motion);
+uint8_t LSM6DS3_Get_Gyro(sensor_motion_t* sensor_motion);
+uint8_t LSM6DS3_Get_Step(sensor_motion_t* sensor_motion);
+
+#endif /*  _LSM6DS3_H_ */

--- a/board/NUCLEO_STM32L073RZ/IAR/lorawan/TencentOS_tiny.ewp
+++ b/board/NUCLEO_STM32L073RZ/IAR/lorawan/TencentOS_tiny.ewp
@@ -1124,13 +1124,13 @@
         </file>
     </group>
     <group>
-        <name>Drivers/CMSIS</name>
-        <file>
-            <name>$PROJ_DIR$\..\..\BSP\Src\system_stm32l0xx.c</name>
-        </file>
-    </group>
-    <group>
         <name>Drivers/STM32L0xx_HAL_Driver</name>
+        <group>
+            <name>Drivers/CMSIS</name>
+            <file>
+                <name>$PROJ_DIR$\..\..\BSP\Src\system_stm32l0xx.c</name>
+            </file>
+        </group>
         <file>
             <name>$PROJ_DIR$\..\..\..\..\platform\vendor_bsp\st\STM32L0xx_HAL_Driver\Src\stm32l0xx_hal.c</name>
         </file>
@@ -1145,6 +1145,9 @@
         </file>
         <file>
             <name>$PROJ_DIR$\..\..\..\..\platform\vendor_bsp\st\STM32L0xx_HAL_Driver\Src\stm32l0xx_hal_flash_ex.c</name>
+        </file>
+        <file>
+            <name>$PROJ_DIR$\..\..\..\..\platform\vendor_bsp\st\STM32L0xx_HAL_Driver\Src\stm32l0xx_hal_flash_ex2.c</name>
         </file>
         <file>
             <name>$PROJ_DIR$\..\..\..\..\platform\vendor_bsp\st\STM32L0xx_HAL_Driver\Src\stm32l0xx_hal_flash_ramfunc.c</name>

--- a/board/NUCLEO_STM32L073RZ/IAR/lorawan/TencentOS_tiny.ewp
+++ b/board/NUCLEO_STM32L073RZ/IAR/lorawan/TencentOS_tiny.ewp
@@ -369,6 +369,7 @@
                     <state>$PROJ_DIR$\..\..\BSP\HardWare\LPS22HB</state>
                     <state>$PROJ_DIR$\..\..\BSP\HardWare\Common</state>
                     <state>$PROJ_DIR$\..\..\BSP\HardWare\LIS3MDL</state>
+                    <state>$PROJ_DIR$\..\..\BSP\HardWare\LSM6DS3</state>
                 </option>
                 <option>
                     <name>CCStdIncCheck</name>
@@ -1077,6 +1078,12 @@
                 <name>LPS22HB</name>
                 <file>
                     <name>$PROJ_DIR$\..\..\BSP\HardWare\LPS22HB\LPS22HB.c</name>
+                </file>
+            </group>
+            <group>
+                <name>LSM6DS3</name>
+                <file>
+                    <name>$PROJ_DIR$\..\..\BSP\HardWare\LSM6DS3\LSM6DS3.c</name>
                 </file>
             </group>
             <file>

--- a/board/NUCLEO_STM32L073RZ/IAR/lorawan/TencentOS_tiny.ewt
+++ b/board/NUCLEO_STM32L073RZ/IAR/lorawan/TencentOS_tiny.ewt
@@ -1258,13 +1258,13 @@
         </file>
     </group>
     <group>
-        <name>Drivers/CMSIS</name>
-        <file>
-            <name>$PROJ_DIR$\..\..\BSP\Src\system_stm32l0xx.c</name>
-        </file>
-    </group>
-    <group>
         <name>Drivers/STM32L0xx_HAL_Driver</name>
+        <group>
+            <name>Drivers/CMSIS</name>
+            <file>
+                <name>$PROJ_DIR$\..\..\BSP\Src\system_stm32l0xx.c</name>
+            </file>
+        </group>
         <file>
             <name>$PROJ_DIR$\..\..\..\..\platform\vendor_bsp\st\STM32L0xx_HAL_Driver\Src\stm32l0xx_hal.c</name>
         </file>
@@ -1279,6 +1279,9 @@
         </file>
         <file>
             <name>$PROJ_DIR$\..\..\..\..\platform\vendor_bsp\st\STM32L0xx_HAL_Driver\Src\stm32l0xx_hal_flash_ex.c</name>
+        </file>
+        <file>
+            <name>$PROJ_DIR$\..\..\..\..\platform\vendor_bsp\st\STM32L0xx_HAL_Driver\Src\stm32l0xx_hal_flash_ex2.c</name>
         </file>
         <file>
             <name>$PROJ_DIR$\..\..\..\..\platform\vendor_bsp\st\STM32L0xx_HAL_Driver\Src\stm32l0xx_hal_flash_ramfunc.c</name>

--- a/board/NUCLEO_STM32L073RZ/IAR/lorawan/TencentOS_tiny.ewt
+++ b/board/NUCLEO_STM32L073RZ/IAR/lorawan/TencentOS_tiny.ewt
@@ -1213,6 +1213,12 @@
                     <name>$PROJ_DIR$\..\..\BSP\HardWare\LPS22HB\LPS22HB.c</name>
                 </file>
             </group>
+            <group>
+                <name>LSM6DS3</name>
+                <file>
+                    <name>$PROJ_DIR$\..\..\BSP\HardWare\LSM6DS3\LSM6DS3.c</name>
+                </file>
+            </group>
             <file>
                 <name>$PROJ_DIR$\..\..\BSP\HardWare\Common\bsp.c</name>
             </file>

--- a/devices/rhf76_lora/RHF76.h
+++ b/devices/rhf76_lora/RHF76.h
@@ -69,9 +69,11 @@ typedef enum lora_key_type {
 #define RHF76_ATCMD_FMT_SEND_MSGHEX             "AT+MSGHEX=\"%s\"\r\n"
 
 #define RHF76_ATCMD_SET_REPT                    "AT+REPT=%d\r\n"
+#define RHF76_ATCMD_SET_DELAY                   "AT+DELAY=%s\r\n"
 
 #define RHF76_ATCMD_SET_BAND_CN470              "AT+DR=CN470\r\n"
 #define RHF76_ATCMD_REPLY_BAND_CN470            "+DR: CN470"
+#define RHF76_ATCMD_SET_DATA_RATE               "AT+DR=%d\r\n"
 
 #define RHF76_ATCMD_SET_CHANNEL                 "at+ch=num,80-87\r\n"
 #define RHF76_ATCMD_SET_ADR_OFF                 "at+adr=off\r\n"
@@ -83,6 +85,67 @@ typedef enum lora_key_type {
 #define RHF76_ATCMD_REPLY_MODE_LWABP            "+MODE: LWABP"
 
 int rhf76_lora_init(hal_uart_port_t uart_port);
+
+/**
+  * @brief  set the delay for RX1,RX2,JRX1,JRX2 OR query current delay config
+  * @note   Examples:
+  *         to set the delay(ms):
+  *           rhf76_set_delay("RX1,2000"); 
+  *
+  *         to query current delay config:     
+  *           rhf76_set_delay("?");
+  *
+  * @param  params     operation string
+  * 
+  * @retval int Status
+  */
+int rhf76_set_delay(char *param);
+
+/**
+  * @brief  set repeat times when sending unconfirmed message 
+  * @note   it is equal to sending
+  *         AT+REPT=2 
+  *         +REPT: 2
+  *             
+  * @param  num       repeat times
+  * 
+  * @retval int Status
+  */
+int rhf76_set_repeat(uint8_t num);
+
+
+/**
+  * @brief  set date rate, which would affect the maximum payload size 
+  * @note   this function is for DEBUG purpose only, it allows user to execute
+  *         AT+ commands by passing the AT+ command to the function as an arg-
+  *         ument. 
+  *         For example,users can query the RF configuration by following code:
+  *
+  *         rhf76_at_cmd_exe("AT+MODE=TEST\r\n");
+  *         rhf76_at_cmd_exe("AT+TEST=?\r\n");
+  *
+  * @param  num     data rate 
+  * 
+  * @retval int Status
+  */
+int rhf76_set_data_rate(uint8_t num);
+
+
+/**
+  * @brief  execute AT+ commands 
+  * @note   this function is for DEBUG purpose only, it allows user to execute
+  *         AT+ commands by passing the AT+ command to the function as an arg-
+  *         ument. 
+  *         For example,users can query the RF configuration by following code:
+  *
+  *         rhf76_at_cmd_exe("AT+MODE=TEST\r\n");
+  *         rhf76_at_cmd_exe("AT+TEST=?\r\n");
+  *
+  * @param  cmd       AT+ commands
+  * 
+  * @retval int Status
+  */
+int rhf76_at_cmd_exe(char *cmd);
 
 #endif /* __RHF76_H__ */
 

--- a/examples/LoRaWAN/lora_demo.h
+++ b/examples/LoRaWAN/lora_demo.h
@@ -1,19 +1,16 @@
 #ifndef __APP_DEMO_H__
 #define __APP_DEMO_H__
 
+#include <stdbool.h>
 #include "mcu_init.h"
 #include "tos_at.h"
 #include "string.h"
 #include "cmsis_os.h"
 #include "lora_module_wrapper.h"
+
 #ifdef __cplusplus
  extern "C" {
 #endif
-
-typedef struct
-{
-    char data[32];
-}ReportData_TypeDef;
 
 void application_entry(void *arg);
 #ifdef __cplusplus

--- a/net/at/include/tos_at.h
+++ b/net/at/include/tos_at.h
@@ -93,6 +93,7 @@ typedef struct at_echo_st {
     size_t              __w_idx;
     int                 __is_expecting;
     k_sem_t             __expect_notify;
+    int                 fuzzy_matching;
 } at_echo_t;
 
 typedef void (*at_event_callback_t)(void);
@@ -268,7 +269,8 @@ __API__ int tos_at_init(hal_uart_port_t uart_port, at_event_t *event_table, size
  *
  * @attention None
  *
- * @return  None
+ * @return  
+None
  */
 __API__ void tos_at_deinit(void);
 
@@ -287,6 +289,22 @@ __API__ void tos_at_deinit(void);
  * @retval  0               create successfully.
  */
 __API__ int tos_at_echo_create(at_echo_t *echo, char *buffer, size_t buffer_size, char *echo_expect);
+
+/**
+ * @brief Create a echo struct with fuzzy matching for expected echo.
+ *
+ * @attention None
+ *
+ * @param[in]   echo                    pointer to the echo struct.
+ * @param[out]  buffer                  buffer to hold the received message from the module.
+ * @param[in]   buffer_size             size of the buffer.
+ * @param[in]   echo_expect_contains    if the echo message contains echo_expect_contains, it is a matching.
+ *
+ * @return  errcode
+ * @retval  -1              create failed(error).
+ * @retval  0               create successfully.
+ */
+__API__ int tos_at_echo_fuzzy_matching_create(at_echo_t *echo, char *buffer, size_t buffer_size, char *echo_expect_contains);
 
 /**
  * @brief Execute an at command.

--- a/net/at/src/tos_at.c
+++ b/net/at/src/tos_at.c
@@ -161,9 +161,18 @@ __STATIC__ int at_is_echo_expect(void)
         return 0;
     }
 
+    if(at_echo->fuzzy_matching){
+      if(strstr(recv_buffer, expect)!=NULL){
+        return 0;
+      }
+      return -1;
+    }
+    
     if (strncmp(expect, recv_buffer, expect_len) == 0) {
         return 1;
     }
+    
+    
 
     return 0;
 }
@@ -337,6 +346,28 @@ __API__ int tos_at_echo_create(at_echo_t *echo, char *buffer, size_t buffer_size
     echo->status            = AT_ECHO_STATUS_NONE;
     echo->__w_idx           = 0;
     echo->__is_expecting    = K_FALSE;
+    echo->fuzzy_matching    = K_FALSE;
+    return 0;
+}
+
+__API__ int tos_at_echo_fuzzy_matching_create(at_echo_t *echo, char *buffer, size_t buffer_size, char *echo_expect_contains)
+{
+    if (!echo) {
+        return -1;
+    }
+
+    if (buffer) {
+        memset(buffer, 0, buffer_size);
+    }
+
+    echo->buffer            = buffer;
+    echo->buffer_size       = buffer_size;
+    echo->echo_expect       = echo_expect_contains;
+    echo->line_num          = 0;
+    echo->status            = AT_ECHO_STATUS_NONE;
+    echo->__w_idx           = 0;
+    echo->__is_expecting    = K_FALSE;
+    echo->fuzzy_matching    = K_TRUE;
     return 0;
 }
 

--- a/platform/vendor_bsp/st/STM32L0xx_HAL_Driver/Inc/stm32l0xx_hal_flash_ex2.h
+++ b/platform/vendor_bsp/st/STM32L0xx_HAL_Driver/Inc/stm32l0xx_hal_flash_ex2.h
@@ -1,0 +1,43 @@
+/**
+  ******************************************************************************
+  * @file    stm32l0xx_hal_flash_ex2.h
+  * @author  jieranzhi
+  * @date    2020/04/02 14:59 CST
+  * @brief   Header file of Flash EEPROM.
+  ******************************************************************************
+  * @attention
+  *
+  * this file implementes FLASH read operations for stm32l0xx series(category 5 
+  * devices), to implement a morefunctions, please refer to RM0367, which could 
+  * be downloaded from:
+  * https://www.st.com/resource/en/reference_manual/dm00095744-ultra-low-power-
+  * stm32l0x3-advanced-arm-based-32-bit-mcus-stmicroelectronics.pdf
+  ******************************************************************************  
+  */
+
+/* Define to prevent recursive inclusion -------------------------------------*/
+#ifndef __STM32L0xx_HAL_FLASH_EX2_H
+#define __STM32L0xx_HAL_FLASH_EX2_H
+
+#ifdef __cplusplus
+ extern "C" {
+#endif
+
+/* Includes ------------------------------------------------------------------*/
+#include "stm32l0xx_hal.h"
+   
+/* Include FLASH HAL Extended module */
+#include "stm32l0xx_hal_flash_ex.h"  
+#include "stm32l0xx_hal_flash_ramfunc.h"
+   
+/* Exported functions --------------------------------------------------------*/
+void HAL_FLASH_Prepare_Reading(uint8_t WaitState);
+HAL_StatusTypeDef HAL_FLASH_ReadWord(uint32_t Address, uint32_t* Data);
+HAL_StatusTypeDef HAL_FLASH_ReadHalfWord(uint32_t Address, uint16_t* Data);
+
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* __STM32L0xx_HAL_FLASH_EX2_H */

--- a/platform/vendor_bsp/st/STM32L0xx_HAL_Driver/Src/stm32l0xx_hal_flash_ex2.c
+++ b/platform/vendor_bsp/st/STM32L0xx_HAL_Driver/Src/stm32l0xx_hal_flash_ex2.c
@@ -1,0 +1,89 @@
+/**
+  ******************************************************************************
+  * @file    stm32l0xx_hal_flash_eeprom.c
+  * @author  jieranzhi
+  * @date    2020/04/02 14:59 CST
+  * @brief   implementation of Flash EEPROM operations.
+  ******************************************************************************
+  * @attention
+  *
+  * this file implementes FLASH read operations for stm32l0xx series(category 5 
+  * devices), to implement a morefunctions, please refer to RM0367, which could 
+  * be downloaded from:
+  * https://www.st.com/resource/en/reference_manual/dm00095744-ultra-low-power-
+  * stm32l0x3-advanced-arm-based-32-bit-mcus-stmicroelectronics.pdf
+  ******************************************************************************  
+  */
+
+#include "stm32l0xx_hal_flash_ex2.h"
+
+/**
+  * @brief  set the correct number of wait states, and set the clock of the memory 
+            interface 
+  * @note   The user must set the correct number of wait states (LATENCY bit in 
+  *         the FLASH_ACR register). No control is done to verify if the frequency
+  *         or the power used is correct, with respect to the number of wait 
+  *         states. A wrong number of wait states can generate wrong read values 
+  *         (high frequency and 0 wait states) or a long time to execute a code 
+  *         (low frequency with 1 wait state).
+  * @param  correct number of wait states
+  */
+void HAL_FLASH_Prepare_Reading(uint8_t WaitState)
+{
+    __HAL_RCC_MIF_CLK_ENABLE();
+    __HAL_FLASH_SET_LATENCY(WaitState);
+}
+
+/**
+  * @brief  Read word (4 bytes) from a specified address
+  * @note   To correctly run this function, the HAL_FLASH_Prepare_Reading(...)
+  *         function must be called before.
+  *
+  * @param  Address       Specifie the address to be read from.
+  * @param  Data          Specifie the data to store the 
+  * 
+  * @retval HAL_StatusTypeDef HAL Status
+  */
+HAL_StatusTypeDef HAL_FLASH_ReadWord(uint32_t Address, uint32_t* Data)
+{
+  HAL_StatusTypeDef status = HAL_ERROR;
+  
+  /* Check the parameters */
+  assert_param(IS_FLASH_PROGRAM_ADDRESS(Address)||IS_FLASH_DATA_ADDRESS(Address));
+
+  /* Wait for last operation to be completed */
+  status = FLASH_WaitForLastOperation(FLASH_TIMEOUT_VALUE);
+  
+  if(status == HAL_OK)
+  {
+    *Data = *(__IO uint32_t*)Address; 
+  }
+  return status;
+}
+
+/**
+  * @brief  Read half-word (2 bytes) from a specified address
+  * @note   To correctly run this function, the HAL_FLASH_Prepare_Reading(...)
+  *         function must be called before.
+  *
+  * @param  Address       Specifie the address to be read from.
+  * @param  Data          Specifie the data to store the 
+  * 
+  * @retval HAL_StatusTypeDef HAL Status
+  */
+HAL_StatusTypeDef HAL_FLASH_ReadHalfWord(uint32_t Address, uint16_t* Data)
+{  
+  HAL_StatusTypeDef status = HAL_ERROR;
+  
+  /* Check the parameters */
+  assert_param(IS_FLASH_PROGRAM_ADDRESS(Address)||IS_FLASH_DATA_ADDRESS(Address));
+
+  /* Wait for last operation to be completed */
+  status = FLASH_WaitForLastOperation(FLASH_TIMEOUT_VALUE);
+  
+  if(status == HAL_OK)
+  {
+    *Data = *(__IO uint16_t*)Address; 
+  }
+  return status;
+}


### PR DESCRIPTION
1. implemented HAL_StatusTypeDef HAL_FLASH_ReadWord(uint32_t Address, uint32_t* Data); and HAL_StatusTypeDef HAL_FLASH_ReadHalfWord(uint32_t Address, uint16_t* Data); which allows user to read the internal FLASH (with out read protection). these functions can be found at stm32l0xx_hal_flash_ex2.h and stm32l0xx_hal_flash_ex2.c.

2. implemeted device_config struct to store device configurations, e.g. magnetometer fullscale, report period, etc.

3. added demonstration code of using flash reading apis in lora_demo.c, in which the configuration sent from the cloud is stored into the internal Data EEPROM bank1, and each time when the device is booted, the configurations would be loaded from the Data EEPROM and used to initialize the application.