### PR TITLE
Fix possible use of uninitialized variables in m5310a.c

### DIFF
--- a/devices/m5310a/m5310a.c
+++ b/devices/m5310a/m5310a.c
@@ -428,7 +428,7 @@ __STATIC__ void m5310a_incoming_udp(void) {
 
 __STATIC__ void m5310a_socket_close_event(void) {
     int id = -1;
-    uint8_t data;
+    uint8_t data = 0;
     while (data != '\n') {
         if (tos_at_uart_read(&data, 1) != 1) {
             return;


### PR DESCRIPTION
In function m5310a_socket_close_event, **data** is uninitialized but it is used on line 432. Just like m5310a_incoming_udp, m5310a_incoming_data and so on, it can be assigned to 0.