### PR TITLE
Fix possible use of uninitialized variables in sys_arch.c

### DIFF
--- a/net/lwip/port/src/sys_arch.c
+++ b/net/lwip/port/src/sys_arch.c
@@ -218,7 +218,7 @@ sys_thread_t sys_thread_new(const char *name, lwip_thread_fn function, void *arg
     sys_thread_t task;
     k_stack_t *task_stack;
 
-    task = tos_mmheap_alloc(sizeof(k_task_t));
+    task = tos_mmheap_calloc(1, sizeof(k_task_t));
     if (!task) {
         printf("[sys_arch]:memalloc k_task_t fail!\n");
         return NULL;


### PR DESCRIPTION
In net/lwip/port/sys/sys_arch.c on line 221, tos_mmheap_alloc is called to allocate a block for **task**. Then on line 234, tos_task_create is called with argument task.
In kernel/core/tos_task.c on line 100, if TOS_CFG_OBJECT_VERIFY_EN > 0u, knl_object_verify will be called in macro TOS_OBJ_TEST_RC. In this function, **task->knl_obj.type** is used but it is not initialized.
So maybe tos_mmheap_calloc is better when allocate a block for **task** in function sys_thread_new.