### PR TITLE
Fix some uses of uninitialized variables cased by tos_task_create

### DIFF
--- a/components/connectivity/mqttclient/platform/TencentOS-tiny/platform_thread.c
+++ b/components/connectivity/mqttclient/platform/TencentOS-tiny/platform_thread.c
@@ -18,7 +18,7 @@ platform_thread_t *platform_thread_init( const char *name,
     platform_thread_t *thread;
     k_err_t err;
     k_stack_t *thread_stack;
-    thread = platform_memory_alloc(sizeof(platform_thread_t));
+    thread = platform_memory_calloc(1, sizeof(platform_thread_t));
     thread_stack = (k_stack_t*) platform_memory_alloc(stack_size);
     
     err = tos_task_create(&(thread->thread), 

--- a/kernel/core/tos_task.c
+++ b/kernel/core/tos_task.c
@@ -250,7 +250,7 @@ __API__ k_err_t tos_task_create_dyn(k_task_t **task,
         return K_ERR_TASK_PRIO_INVALID;
     }
 
-    the_task = tos_mmheap_alloc(sizeof(k_task_t));
+    the_task = tos_mmheap_calloc(1, sizeof(k_task_t));
     if (!the_task) {
         return K_ERR_TASK_OUT_OF_MEMORY;
     }

--- a/osal/posix/pthread.c
+++ b/osal/posix/pthread.c
@@ -551,7 +551,7 @@ __API__ int pthread_create(pthread_t *thread, const pthread_attr_t *attr, void *
     }
 
     if (!the_attr.stackaddr_valid) {
-        stackaddr   = tos_mmheap_alloc(stacksize);
+        stackaddr   = tos_mmheap_calloc(1, stacksize);
         if (!stackaddr) {
             errcode = ENOMEM;
             goto errout0;


### PR DESCRIPTION
If TOS_CFG_OBJECT_VERIFY_EN > 0u, some uninitialized variables like task->knl_obj.type may be used in function knl_object_verify which is called by tos_task_create.