### PR TITLE
修正了KEIL移植文档中的错误

### DIFF
--- a/doc/10.Porting_Manual_for_KEIL.md
+++ b/doc/10.Porting_Manual_for_KEIL.md
@@ -7,8 +7,6 @@ TencentOS tiny目前主要支持ARM Cortex M核芯片的移植，比如STM32 基
 
 调试ARM Cortex M核还需要仿真器， NUCLEO-L073RZ自带ST-Link调试器，如果您的开发板或者芯片模组没有板载仿真器，就需要连接外置的仿真器，如J-Link、U-Link之类的。
 
-​     
-
 ###   2.准备编译器环境
 
 本移植指南针对的是Keil编译器，所以我们移植内核前需要先安装Keil编译器，能编译ARM Cortex M核的Keil编译器现在也叫MDK，最新版本5.28a,下载地址为：[https://www.keil.com/demo/eval/arm.htm]()
@@ -21,7 +19,7 @@ TencentOS tiny目前主要支持ARM Cortex M核芯片的移植，比如STM32 基
 
 本教程使用ST官方的STM32CubeMX软件来自动化生成MDK裸机工程，STM32CubeMX的下载地址为：
 
-[     https://www.st.com/content/st_com/zh/products/development-tools/software-development-tools/stm32-software-development-tools/stm32-configurators-and-code-generators/stm32cubemx.html]()
+[https://www.st.com/content/st_com/zh/products/development-tools/software-development-tools/stm32-software-development-tools/stm32-configurators-and-code-generators/stm32cubemx.html]()
 
  安装STM32CubeMx还需要事先安装好JDK环境，您可以在互联网上查找如何安装和配置JDK环境，此处不再赘述。
 
@@ -71,11 +69,9 @@ TencentOS tiny目前主要支持ARM Cortex M核芯片的移植，比如STM32 基
 ![](https://main.qcloudimg.com/raw/3d071b29139ba20bba78c5521838efc2.png)
      
 这样NUCLEO-L073RZ裸机工程生成完成，该工程可直接编译并烧写在板子上运行。
-     
+
 ###   4. 准备TencentOS tiny的源码
 TencentOS tiny的源码已经开源，github下载地址为：[https://github.com/Tencent/TencentOS-tiny.git]()
-
-​     
 
 |一级目录 | 二级目录 | 说明 |
 |---------|---------|---------|
@@ -186,9 +182,9 @@ TencentOS tiny所有要添加的头文件目录如下：
 #endif
 
 ```
-   按照上面的模板配置好TencentOS tiny的各项功能后，将tos_config.h 文件放入要移植的board工程目录下即可，例如本教程是放到board\NUCLEO_L073RZ\TOS_CONFIG目录下。
+按照上面的模板配置好TencentOS tiny的各项功能后，将tos_config.h 文件放入要移植的board工程目录下即可，例如本教程是放到board\NUCLEO_L073RZ\TOS_CONFIG目录下。
 
-   这样，TencentOS tiny的源码就全部添加完毕了。
+这样，TencentOS tiny的源码就全部添加完毕了。
 
 ##  三、创建TencentOS tiny任务，测试移植结果
 
@@ -271,11 +267,9 @@ TencentOS tiny所有要添加的头文件目录如下：
 
 ![](https://main.qcloudimg.com/raw/3ce4c79796f4261fd45d26caa64e1e24.png)
 
-   按照上图指示，进行编译下载到开发板即可完成TencentOS tiny的测试，如下图所示，可以看到串口交替打印信息，表示两个任务正在进行调度，切换运行：
+按照上图指示，进行编译下载到开发板即可完成TencentOS tiny的测试，如下图所示，可以看到串口交替打印信息，表示两个任务正在进行调度，切换运行：
 
 ![](https://main.qcloudimg.com/raw/b0f9d16064c4aeffa5f8c3dfbfbc0dbd.png)
-
-   
 
 
 

--- a/doc/10.Porting_Manual_for_KEIL.md
+++ b/doc/10.Porting_Manual_for_KEIL.md
@@ -7,7 +7,7 @@ TencentOS tiny目前主要支持ARM Cortex M核芯片的移植，比如STM32 基
 
 调试ARM Cortex M核还需要仿真器， NUCLEO-L073RZ自带ST-Link调试器，如果您的开发板或者芯片模组没有板载仿真器，就需要连接外置的仿真器，如J-Link、U-Link之类的。
 
-     
+​     
 
 ###   2.准备编译器环境
 
@@ -32,33 +32,33 @@ TencentOS tiny目前主要支持ARM Cortex M核芯片的移植，比如STM32 基
 ![](https://main.qcloudimg.com/raw/5c6a1eca65dbec90fe73402cc39a2fa4.png)
 
 #### 3.2 选择MCU型号
-     
+
 ![](https://main.qcloudimg.com/raw/70d3cc4e69c36a9d9707efde2c0e2472.png)
      
 如上图所示：通过MCU筛选来找到自己开发板对应的芯片型号，双击后弹出工程配置界面，如下图：
      
 ![](https://main.qcloudimg.com/raw/f8f05e6b8ef07fc9d30fa3c51a0c82fe.png)
 #### 3.3 Pin设置界面配置时钟源     
-     
+
 ![](https://main.qcloudimg.com/raw/01dcc7684d340dca5d84b88e5b6b707b.png)
 
 #### 3.4 Pin设置界面配置串口
-     
+
 ![](https://main.qcloudimg.com/raw/ffd52f709fd148ba7e654c8ce320d0ad.png)
      
 #### 3.5 Pin设置界面配置GPIO
 ![](https://main.qcloudimg.com/raw/278977b909359db187519b8d6a9125d4.png)
      
 #### 3.6 配置总线时钟
-     
+
 ![](https://main.qcloudimg.com/raw/72f3f1ed823d1e57bac1eda0d0487b2f.png)
      
 #### 3.7 工程生成参数配置
-     
+
 ![](https://main.qcloudimg.com/raw/ac35d9a0aaa1e0e8adcced561cac179b.png)
      
 #### 3.8 代码生成方式配置
-     
+
 ![](https://main.qcloudimg.com/raw/d46ed81804cdb58e6af8c64df5a470ba.png)
      
 #### 3.9 生成工程
@@ -66,7 +66,7 @@ TencentOS tiny目前主要支持ARM Cortex M核芯片的移植，比如STM32 基
 ![](https://main.qcloudimg.com/raw/ecc132f84a548f8802abb7d8aefc8ba9.png)
      
 #### 3.10  keil下的裸机工程
-     
+
 点击生成代码后，生成的裸机工程效果如下：
 ![](https://main.qcloudimg.com/raw/3d071b29139ba20bba78c5521838efc2.png)
      
@@ -75,7 +75,7 @@ TencentOS tiny目前主要支持ARM Cortex M核芯片的移植，比如STM32 基
 ###   4. 准备TencentOS tiny的源码
 TencentOS tiny的源码已经开源，github下载地址为：[https://github.com/Tencent/TencentOS-tiny.git]()
 
-     
+​     
 
 |一级目录 | 二级目录 | 说明 |
 |---------|---------|---------|
@@ -113,7 +113,7 @@ port_s.S 文件是TencentOS tiny的任务调度汇编代码，主要做弹栈压
 ![](https://main.qcloudimg.com/raw/699d9d0d52d3b29e7fb9583fa0bea69c.png)
 
 ### 4. 添加cmsis os源码
-	
+
 cmsis os是TencentOS tiny为了兼容cmsis标准而适配的OS抽象层，可以简化大家将业务从其他RTOS迁移到TencentOS tiny的工作量。
 	
 ![](https://main.qcloudimg.com/raw/bf6450c40da00ecabbd0ad1cd21fed87.png)
@@ -187,14 +187,14 @@ TencentOS tiny所有要添加的头文件目录如下：
 
 ```
    按照上面的模板配置好TencentOS tiny的各项功能后，将tos_config.h 文件放入要移植的board工程目录下即可，例如本教程是放到board\NUCLEO_L073RZ\TOS_CONFIG目录下。
-   
+
    这样，TencentOS tiny的源码就全部添加完毕了。
 
 ##  三、创建TencentOS tiny任务，测试移植结果
 
 ### 1. 修改部分代码
 #### 修改stm32l0xx_it.c的中断函数,在stm32l0xx_it.c文件中包含 tos_k.h 头文件
-![](https://main.qcloudimg.com/raw/172245ad4fd6768dca798fd2db209755.png)
+![](https://s1.ax1x.com/2020/10/20/BpTL60.png)
 
 在stm32l0xx_it.c文件中的PendSV_Handler函数前添加___weak关键字，因为该函数在TencentOS tiny的调度汇编中已经重新实现；同时在SysTick_Handler函数中添加TencentOS tiny的调度处理函数，如下图所示：
 	
@@ -270,11 +270,11 @@ TencentOS tiny所有要添加的头文件目录如下：
 ### 3. 编译下载测试TencentOS tiny移植结果
 
 ![](https://main.qcloudimg.com/raw/3ce4c79796f4261fd45d26caa64e1e24.png)
-   
+
    按照上图指示，进行编译下载到开发板即可完成TencentOS tiny的测试，如下图所示，可以看到串口交替打印信息，表示两个任务正在进行调度，切换运行：
-   
+
 ![](https://main.qcloudimg.com/raw/b0f9d16064c4aeffa5f8c3dfbfbc0dbd.png)
-   
+
    
 
 


### PR DESCRIPTION
修正了KEIL移植文档中tos_k.h头文件添加时文字和图片不相符的情况, 并调整了部分缩进, 使阅览更为美观(本图片采用https://imgchr.com托管, 原因是不清楚文档中的https://main.qcloudimg.com如何上传图片)