### PR TITLE
fix a bug; port nimble event queue pool memory overflow 

### DIFF
--- a/components/connectivity/Bluetooth_5.0/porting/TencentOS_tiny/src/npl_os_tencenos_tiny.c
+++ b/components/connectivity/Bluetooth_5.0/porting/TencentOS_tiny/src/npl_os_tencenos_tiny.c
@@ -27,12 +27,12 @@ volatile int ble_npl_in_critical = 0;
 void
 npl_tencentos_tiny_eventq_init(struct ble_npl_eventq *evq)
 {
-    void *msg_pool = tos_mmheap_alloc(sizeof(void *));
+#define EVENT_Q_MSG_CNT     32
+    void *msg_pool = tos_mmheap_alloc(sizeof(void *) * EVENT_Q_MSG_CNT);
     if (!msg_pool) {
         return;
     }
 
-#define EVENT_Q_MSG_CNT     32
     tos_msg_q_create(&evq->q, msg_pool, EVENT_Q_MSG_CNT);
 }
 


### PR DESCRIPTION
- pool 分配个数错误
nimble 官方适配的 freertos
![image](https://user-images.githubusercontent.com/10562877/99875453-c9c03e80-2c2a-11eb-991f-95215cd3371d.png)
