### PR TITLE
Update 28.BLE_Device_Quick_Start.md

### DIFF
--- a/doc/28.BLE_Device_Quick_Start.md
+++ b/doc/28.BLE_Device_Quick_Start.md
@@ -109,7 +109,7 @@
    ![](image/BLE/llsync4.jpg)
 4. 在【我的设备】中打开刚刚添加的蓝牙设备。  
    ![](image/BLE/llsync5.jpg)
-5. 点击右侧的【立即连接】连接设备，如连接失败。  
+5. 点击右侧的【立即连接】连接设备。  
    ![](image/BLE/llsync6.jpg)
 6. 连接成功后点击【电灯开关】，可以看到开发版上【LED1】随之变化。  
    ![](image/BLE/llsync7.jpg)


### PR DESCRIPTION
本文档GitHub上配套说明的图未能显示。删除引发歧义的语句

**“，如连接失败”。**

note: 蓝牙设备扫描配对之后，点击连接，出现连接失败的可能性多种多样，如可能是连接占用，也可能是蓝牙设备电量不足，各种原因。建议不在此处展开，容易引起歧义。