### PR TITLE
解决modbus demo与hello world共用stm32f4xx_it.c导致的编译问题

### DIFF
--- a/board/ALIENTEK_EXPLORER_STM32F407ZGT6/BSP/Src/stm32f4xx_it.c
+++ b/board/ALIENTEK_EXPLORER_STM32F407ZGT6/BSP/Src/stm32f4xx_it.c
@@ -242,7 +242,7 @@ void USART2_IRQHandler(void)
 	{
 		HAL_UART_Receive(&huart2,&tmp,1,1);
 	}
-	
+        #ifdef USE_MODBUS
 	else if(__HAL_UART_GET_FLAG(&huart2,UART_FLAG_RXNE)&&__HAL_UART_GET_IT_SOURCE(&huart2,UART_IT_RXNE))
 	{
 		prvvUARTRxISR();
@@ -253,6 +253,7 @@ void USART2_IRQHandler(void)
 		prvvUARTTxReadyISR();
 		
 	}
+        #endif /* USE_MODBUS */
 }
 
 /**
@@ -275,7 +276,9 @@ void USART3_IRQHandler(void)
 void TIM6_DAC_IRQHandler(void)
 {
   /* USER CODE BEGIN TIM6_DAC_IRQn 0 */
-		prvvTIMERExpiredISR();
+  #ifdef USE_MODBUS
+  prvvTIMERExpiredISR();
+  #endif/* USE_MODBUS */
   /* USER CODE END TIM6_DAC_IRQn 0 */
   HAL_TIM_IRQHandler(&htim6);
   /* USER CODE BEGIN TIM6_DAC_IRQn 1 */

--- a/board/ALIENTEK_EXPLORER_STM32F407ZGT6/BSP/Src/stm32f4xx_it.c
+++ b/board/ALIENTEK_EXPLORER_STM32F407ZGT6/BSP/Src/stm32f4xx_it.c
@@ -242,7 +242,7 @@ void USART2_IRQHandler(void)
 	{
 		HAL_UART_Receive(&huart2,&tmp,1,1);
 	}
-        #if defined USE_MODBUS
+        #if defined (USE_MODBUS)
 	else if(__HAL_UART_GET_FLAG(&huart2,UART_FLAG_RXNE)&&__HAL_UART_GET_IT_SOURCE(&huart2,UART_IT_RXNE))
 	{
 		prvvUARTRxISR();
@@ -276,7 +276,7 @@ void USART3_IRQHandler(void)
 void TIM6_DAC_IRQHandler(void)
 {
   /* USER CODE BEGIN TIM6_DAC_IRQn 0 */
-  #if defined USE_MODBUS
+  #if defined (USE_MODBUS)
   prvvTIMERExpiredISR();
   #endif/* USE_MODBUS */
   /* USER CODE END TIM6_DAC_IRQn 0 */

--- a/board/ALIENTEK_EXPLORER_STM32F407ZGT6/BSP/Src/stm32f4xx_it.c
+++ b/board/ALIENTEK_EXPLORER_STM32F407ZGT6/BSP/Src/stm32f4xx_it.c
@@ -236,13 +236,13 @@ void USART2_IRQHandler(void)
 
   /* USER CODE END USART2_IRQn 1 */
 	
- /* USER CODE BEGIN USART1_IRQn 0 */
+  /* USER CODE BEGIN USART1_IRQn 0 */
 	uint8_t tmp;
 	if(__HAL_UART_GET_FLAG(&huart2,UART_FLAG_PE))//???????
 	{
 		HAL_UART_Receive(&huart2,&tmp,1,1);
 	}
-        #ifdef USE_MODBUS
+        #if defined USE_MODBUS
 	else if(__HAL_UART_GET_FLAG(&huart2,UART_FLAG_RXNE)&&__HAL_UART_GET_IT_SOURCE(&huart2,UART_IT_RXNE))
 	{
 		prvvUARTRxISR();
@@ -276,7 +276,7 @@ void USART3_IRQHandler(void)
 void TIM6_DAC_IRQHandler(void)
 {
   /* USER CODE BEGIN TIM6_DAC_IRQn 0 */
-  #ifdef USE_MODBUS
+  #if defined USE_MODBUS
   prvvTIMERExpiredISR();
   #endif/* USE_MODBUS */
   /* USER CODE END TIM6_DAC_IRQn 0 */

--- a/board/ALIENTEK_EXPLORER_STM32F407ZGT6/KEIL/modbus/ALIENTEK_EXPLORER_STM32F407ZGT6.uvprojx
+++ b/board/ALIENTEK_EXPLORER_STM32F407ZGT6/KEIL/modbus/ALIENTEK_EXPLORER_STM32F407ZGT6.uvprojx
@@ -336,7 +336,7 @@
             <v6Rtti>0</v6Rtti>
             <VariousControls>
               <MiscControls></MiscControls>
-              <Define>USE_HAL_DRIVER,STM32F407xx,USE_HAL_DRIVER,STM32F407xx</Define>
+              <Define>USE_HAL_DRIVER,STM32F407xx,USE_HAL_DRIVER,STM32F407xx,USE_MODBUS</Define>
               <Undefine></Undefine>
               <IncludePath>..\..\BSP\Inc;..\..\..\..\platform\vendor_bsp\st\STM32F4xx_HAL_Driver\Inc;..\..\..\..\platform\vendor_bsp\st\STM32F4xx_HAL_Driver\Inc\Legacy;..\..\..\..\platform\vendor_bsp\st\CMSIS\Device\ST\STM32F4xx\Include;..\..\..\..\platform\vendor_bsp\st\CMSIS\Include;..\..\..\..\arch\arm\arm-v7m\common\include;..\..\..\..\arch\arm\arm-v7m\cortex-m4\armcc;..\..\..\..\kernel\core\include;..\..\..\..\kernel\pm\include;..\..\..\..\osal\cmsis_os;..\..\TOS_CONFIG;..\..\..\..\components\connectivity\Modbus\3rdparty\freemodbus-v1.6\modbus\ascii;..\..\..\..\components\connectivity\Modbus\3rdparty\freemodbus-v1.6\modbus\functions;..\..\..\..\components\connectivity\Modbus\3rdparty\freemodbus-v1.6\modbus\include;..\..\..\..\components\connectivity\Modbus\3rdparty\freemodbus-v1.6\modbus\rtu;..\..\..\..\components\connectivity\Modbus\3rdparty\freemodbus-v1.6\modbus\tcp;..\..\..\..\components\connectivity\Modbus\porting\TencentOS_Tiny</IncludePath>
             </VariousControls>


### PR DESCRIPTION
stm32f4xx_it.c嵌入modbus代码导致helloworld工程编译报错