### PR TITLE
[HUST CSE] Access array elements before Cross border inspection

### DIFF
--- a/board/TencentOS_Tiny_EVB_STM32WL/BSP/Middlewares/LoRaWAN/Mac/LoRaMac.c
+++ b/board/TencentOS_Tiny_EVB_STM32WL/BSP/Middlewares/LoRaWAN/Mac/LoRaMac.c
@@ -4422,17 +4422,19 @@ LoRaMacStatus_t LoRaMacMcChannelSetupRxParams( AddressIdentifier_t groupID, McRx
         return LORAMAC_STATUS_BUSY;
     }
 
+    if( ( groupID >= LORAMAC_MAX_MC_CTX ) || 
+        ( MacCtx.NvmCtx->MulticastChannelList[groupID].ChannelParams.IsEnabled == false ) )
+    {
+        return LORAMAC_STATUS_MC_GROUP_UNDEFINED;
+    }
+    
     DeviceClass_t devClass = MacCtx.NvmCtx->MulticastChannelList[groupID].ChannelParams.Class;
     if( ( devClass == CLASS_A ) || ( devClass > CLASS_C ) )
     {
         return LORAMAC_STATUS_PARAMETER_INVALID;
     }
 
-    if( ( groupID >= LORAMAC_MAX_MC_CTX ) || 
-        ( MacCtx.NvmCtx->MulticastChannelList[groupID].ChannelParams.IsEnabled == false ) )
-    {
-        return LORAMAC_STATUS_MC_GROUP_UNDEFINED;
-    }
+
     *status &= 0x0F; // groupID OK
 
     VerifyParams_t verify;


### PR DESCRIPTION
`DeviceClass_t devClass = MacCtx.NvmCtx->MulticastChannelList[groupID].ChannelParams.Class;`
Before executing this line of code, we'd better first check if the array is out of bounds, rather than placing a check after this line of code.
Code modification: Swap the code position to advance the check for array out of bounds to the front of array access